### PR TITLE
Implement fake ULID generator

### DIFF
--- a/backend/app/CellExtraction/crud.py
+++ b/backend/app/CellExtraction/crud.py
@@ -15,11 +15,13 @@ from sqlalchemy.ext.asyncio import create_async_engine
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import sessionmaker, declarative_base
 from sqlalchemy.sql import select
-import ulid
+import random
 
 
 def get_ulid() -> str:
-    return str(ulid.new())
+    """Return a fake ULID using random digits."""
+    # NOTE: This is a placeholder implementation
+    return "".join(str(random.randint(0, 9)) for _ in range(16))
 
 
 Base = declarative_base()

--- a/backend/app/OAuth2/database.py
+++ b/backend/app/OAuth2/database.py
@@ -2,13 +2,15 @@ from sqlalchemy import Column, Integer, String, DateTime, ForeignKey, Boolean
 from sqlalchemy.orm import sessionmaker, declarative_base
 from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession
 import os
-import ulid
+import random
 
 BaseAuth = declarative_base()
 
 
 def get_ulid() -> str:
-    return str(ulid.new())
+    """Return a fake ULID using random digits."""
+    # NOTE: This is a placeholder implementation
+    return "".join(str(random.randint(0, 9)) for _ in range(16))
 
 
 class User(BaseAuth):

--- a/backend/app/TimeLapseEngine/crud.py
+++ b/backend/app/TimeLapseEngine/crud.py
@@ -20,11 +20,13 @@ from sqlalchemy import BLOB, Column, FLOAT, Integer, String, delete, update, tex
 from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession
 from sqlalchemy.orm import sessionmaker, declarative_base
 from sqlalchemy.sql import select
-import ulid
+import random
 from scipy.optimize import linear_sum_assignment
 
 def get_ulid() -> str:
-    return str(ulid.new())
+    """Return a fake ULID using random digits."""
+    # NOTE: This is a placeholder implementation
+    return "".join(str(random.randint(0, 9)) for _ in range(16))
 
 
 Base = declarative_base()


### PR DESCRIPTION
## Summary
- drop dependency on `ulid` in CRUD modules
- create a fake `get_ulid` that returns a random 16-digit string

## Testing
- `bash backend/app/run_tests.sh` *(fails: `find: './testing': No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_684a67500680832da507004e819a5f8f