### PR TITLE
Add fluo2 display on labeling screen

### DIFF
--- a/backend/app/CellDBConsole/crud.py
+++ b/backend/app/CellDBConsole/crud.py
@@ -1366,6 +1366,27 @@ class CellCrudBase:
             brightness_factor=brightness_factor,
         )
 
+    async def get_cell_fluo2(
+        self,
+        cell_id: str,
+        draw_contour: bool = False,
+        draw_scale_bar: bool = False,
+        brightness_factor: float = 1.0,
+    ) -> StreamingResponse:
+        cell = await self.read_cell(cell_id)
+        if draw_contour:
+            return await self.parse_image(
+                data=cell.img_fluo2,
+                contour=cell.contour,
+                scale_bar=draw_scale_bar,
+                brightness_factor=brightness_factor,
+            )
+        return await self.parse_image(
+            data=cell.img_fluo2,
+            scale_bar=draw_scale_bar,
+            brightness_factor=brightness_factor,
+        )
+
     async def get_cell_contour(self, cell_id: str) -> list[list[float]]:
         cell = await self.read_cell(cell_id)
         return await AsyncChores.async_pickle_loads(cell.contour)

--- a/backend/app/CellDBConsole/router.py
+++ b/backend/app/CellDBConsole/router.py
@@ -170,6 +170,28 @@ async def get_cell_fluo(
     )
 
 
+@router_cell.get("/{cell_id}/{db_name}/{draw_contour}/{draw_scale_bar}/fluo2_image")
+async def get_cell_fluo2(
+    cell_id: str,
+    db_name: str,
+    draw_contour: bool = False,
+    draw_scale_bar: bool = False,
+    brightness_factor: float = 1.0,
+):
+    if "-single_layer" in db_name:
+        raise HTTPException(
+            status_code=404,
+            detail="Fluo does not exist in single layer databases. Please use the ph endpoint.",
+        )
+    await AsyncChores().validate_database_name(db_name)
+    return await CellCrudBase(db_name=db_name).get_cell_fluo2(
+        cell_id=cell_id,
+        draw_contour=draw_contour,
+        draw_scale_bar=draw_scale_bar,
+        brightness_factor=brightness_factor,
+    )
+
+
 @router_cell.get("/{cell_id}/contour/{contour_type}")
 async def get_cell_contour(
     cell_id: str,

--- a/backend/app/CellDBConsole/router.py
+++ b/backend/app/CellDBConsole/router.py
@@ -221,15 +221,23 @@ async def get_cell_morphology(cell_id: str, db_name: str, polyfit_degree: int = 
 
 
 @router_cell.get("/{cell_id}/{db_name}/replot", response_class=StreamingResponse)
-async def replot_cell(cell_id: str, db_name: str, degree: int = 3):
+async def replot_cell(
+    cell_id: str, db_name: str, degree: int = 3, channel: int = 1
+):
     await AsyncChores().validate_database_name(db_name)
-    return await CellCrudBase(db_name=db_name).replot(cell_id=cell_id, degree=degree)
+    return await CellCrudBase(db_name=db_name).replot(
+        cell_id=cell_id, degree=degree, channel=channel
+    )
 
 
 @router_cell.get("/{cell_id}/{db_name}/path", response_class=StreamingResponse)
-async def get_cell_path(cell_id: str, db_name: str, degree: int = 3):
+async def get_cell_path(
+    cell_id: str, db_name: str, degree: int = 3, channel: int = 1
+):
     await AsyncChores().validate_database_name(db_name)
-    return await CellCrudBase(db_name=db_name).find_path(cell_id=cell_id, degree=degree)
+    return await CellCrudBase(db_name=db_name).find_path(
+        cell_id=cell_id, degree=degree, channel=channel
+    )
 
 
 @router_cell.get("/{db_name}/{label}/{cell_id}/mean_fluo_intensities")
@@ -306,10 +314,12 @@ async def get_heatmap(db_name: str, label: str, cell_id: str):
 
 
 @router_cell.get("/{db_name}/{cell_id}/distribution", response_class=StreamingResponse)
-async def get_fluo_distribution(db_name: str, cell_id: str):
+async def get_fluo_distribution(
+    db_name: str, cell_id: str, channel: int = 1
+):
     await AsyncChores().validate_database_name(db_name)
     return await CellCrudBase(db_name=db_name).extract_intensity_and_create_histogram(
-        label="", cell_id=cell_id
+        label="", cell_id=cell_id, channel=channel
     )
 
 
@@ -317,23 +327,29 @@ async def get_fluo_distribution(db_name: str, cell_id: str):
     "/{db_name}/{label}/{cell_id}/distribution_normalized",
     response_class=StreamingResponse,
 )
-async def get_fluo_distribution_normalized(db_name: str, cell_id: str):
+async def get_fluo_distribution_normalized(
+    db_name: str, cell_id: str, channel: int = 1
+):
     await AsyncChores().validate_database_name(db_name)
     return await CellCrudBase(
         db_name=db_name
-    ).extract_normalized_intensity_and_create_histogram(label="", cell_id=cell_id)
+    ).extract_normalized_intensity_and_create_histogram(
+        label="", cell_id=cell_id, channel=channel
+    )
 
 
 @router_cell.get(
     "/{db_name}/{label}/{cell_id}/distribution_normalized/raw_points",
 )
-async def get_fluo_distribution_normalized_raw_points(db_name: str, cell_id: str):
+async def get_fluo_distribution_normalized_raw_points(
+    db_name: str, cell_id: str, channel: int = 1
+):
     await AsyncChores().validate_database_name(db_name)
     return JSONResponse(
         content={
             "raw_points": await CellCrudBase(
                 db_name=db_name
-            ).extract_normalized_intensities_raw(cell_id=cell_id)
+            ).extract_normalized_intensities_raw(cell_id=cell_id, channel=channel)
         }
     )
 
@@ -374,9 +390,11 @@ async def get_paths_plot(db_name: str, label: str = 1):
 
 
 @router_cell.get("/{db_name}/{cell_id}/3d")
-async def get_3d_plot(db_name: str, cell_id: str):
+async def get_3d_plot(db_name: str, cell_id: str, channel: int = 1):
     await AsyncChores().validate_database_name(db_name)
-    image_buf = await CellCrudBase(db_name=db_name).get_cloud_points(cell_id=cell_id)
+    image_buf = await CellCrudBase(db_name=db_name).get_cloud_points(
+        cell_id=cell_id, channel=channel
+    )
     return StreamingResponse(image_buf, media_type="image/png")
 
 

--- a/frontend/src/components/CellOverview.tsx
+++ b/frontend/src/components/CellOverview.tsx
@@ -147,6 +147,7 @@ const CellImageGrid: React.FC = () => {
   const [autoPlay, setAutoPlay] = useState<boolean>(false);
   const [brightnessFactor, setBrightnessFactor] = useState<number>(1.0);
   const [hasFluo2, setHasFluo2] = useState<boolean>(false);
+  const [fluoChannel, setFluoChannel] = useState<'fluo1' | 'fluo2'>('fluo1');
   const [drawMode, setDrawMode] = useState<DrawModeType>(init_draw_mode);
   const [fitDegree, setFitDegree] = useState<number>(4);
   const [engineMode, setEngineMode] = useState<EngineName>("None");
@@ -298,8 +299,9 @@ const CellImageGrid: React.FC = () => {
       switch (mode) {
         case "replot": {
           if (!images[cellId]?.replot) {
+            const channelParam = fluoChannel === 'fluo2' ? 2 : 1;
             const response = await axios.get(
-              `${url_prefix}/cells/${cellId}/${db_name}/replot?degree=${fitDegree}`,
+              `${url_prefix}/cells/${cellId}/${db_name}/replot?degree=${fitDegree}&channel=${channelParam}`,
               { responseType: "blob" }
             );
             const url = URL.createObjectURL(response.data);
@@ -312,8 +314,9 @@ const CellImageGrid: React.FC = () => {
         }
         case "distribution": {
           if (!images[cellId]?.distribution) {
+            const channelParam = fluoChannel === 'fluo2' ? 2 : 1;
             const response = await axios.get(
-              `${url_prefix}/cells/${db_name}/${cellId}/distribution`,
+              `${url_prefix}/cells/${db_name}/${cellId}/distribution?channel=${channelParam}`,
               { responseType: "blob" }
             );
             const url = URL.createObjectURL(response.data);
@@ -326,8 +329,9 @@ const CellImageGrid: React.FC = () => {
         }
         case "distribution_normalized": {
           if (!images[cellId]?.distribution_normalized) {
+            const channelParam = fluoChannel === 'fluo2' ? 2 : 1;
             const response = await axios.get(
-              `${url_prefix}/cells/${db_name}/${selectedLabel}/${cellId}/distribution_normalized`,
+              `${url_prefix}/cells/${db_name}/${selectedLabel}/${cellId}/distribution_normalized?channel=${channelParam}`,
               { responseType: "blob" }
             );
             const url = URL.createObjectURL(response.data);
@@ -340,9 +344,10 @@ const CellImageGrid: React.FC = () => {
         }
         case "path": {
           if (!images[cellId]?.path) {
+            const channelParam = fluoChannel === 'fluo2' ? 2 : 1;
             setIsLoading(true);
             const response = await axios.get(
-              `${url_prefix}/cells/${cellId}/${db_name}/path?degree=${fitDegree}`,
+              `${url_prefix}/cells/${cellId}/${db_name}/path?degree=${fitDegree}&channel=${channelParam}`,
               { responseType: "blob" }
             );
             const url = URL.createObjectURL(response.data);
@@ -369,8 +374,9 @@ const CellImageGrid: React.FC = () => {
         }
         case "cloud_points": {
           if (!images[cellId]?.cloud_points) {
+            const channelParam = fluoChannel === 'fluo2' ? 2 : 1;
             const response = await axios.get(
-              `${url_prefix}/cells/${db_name}/${cellId}/3d`,
+              `${url_prefix}/cells/${db_name}/${cellId}/3d?channel=${channelParam}`,
               { responseType: "blob" }
             );
             const url = URL.createObjectURL(response.data);
@@ -425,7 +431,7 @@ const CellImageGrid: React.FC = () => {
     const cellId = cellIds[currentIndex];
     fetchAdditionalImage(drawMode, cellId);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [drawMode, cellIds, currentIndex, fitDegree]);
+  }, [drawMode, cellIds, currentIndex, fitDegree, fluoChannel]);
 
   //------------------------------------
   // 現在のセルIDに対応した初期ラベルを取得
@@ -893,6 +899,24 @@ const CellImageGrid: React.FC = () => {
                   fullWidth
                 />
               </Grid>
+              {hasFluo2 && (
+                <Grid item xs={2}>
+                  <FormControl fullWidth variant="outlined" size="small">
+                    <InputLabel id="fluo-channel-label">Fluo</InputLabel>
+                    <Select
+                      labelId="fluo-channel-label"
+                      label="Fluo"
+                      value={fluoChannel}
+                      onChange={(e) =>
+                        setFluoChannel(e.target.value as 'fluo1' | 'fluo2')
+                      }
+                    >
+                      <MenuItem value="fluo1">fluo1</MenuItem>
+                      <MenuItem value="fluo2">fluo2</MenuItem>
+                    </Select>
+                  </FormControl>
+                </Grid>
+              )}
               <Grid item xs={3}>
                 <FormControl fullWidth variant="outlined">
                   <InputLabel id="manual-label-select-label">Manual Label</InputLabel>


### PR DESCRIPTION
## Summary
- add backend endpoint and CRUD method to fetch fluo2 images
- detect fluo2 presence on the frontend and fetch it
- display ph, fluo1 and fluo2 in labeling UI if available

## Testing
- `bash backend/app/run_tests.sh` *(fails: ModuleNotFoundError: httpx)*
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852458e5dc0832d89f265a39171e862