### PR TITLE
Fix layout for brightness and label controls

### DIFF
--- a/frontend/src/components/CellOverview.tsx
+++ b/frontend/src/components/CellOverview.tsx
@@ -884,6 +884,7 @@ const CellImageGrid: React.FC = () => {
                   style={{ color: "black" }}
                 />
               </Grid>
+              <Grid item xs={12} />
               <Grid item xs={3}>
                 <TextField
                   label="Brightness"
@@ -901,7 +902,7 @@ const CellImageGrid: React.FC = () => {
               </Grid>
               {hasFluo2 && (
                 <Grid item xs={2}>
-                  <FormControl fullWidth variant="outlined" size="small">
+                  <FormControl fullWidth variant="outlined">
                     <InputLabel id="fluo-channel-label">Fluo</InputLabel>
                     <Select
                       labelId="fluo-channel-label"


### PR DESCRIPTION
## Summary
- tidy up UI for manual labeling
- keep brightness, Fluo and Manual Label on a single row
- ensure Fluo dropdown matches other control heights

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68524a4431b0832db3352440b0e4ab76