### PR TITLE
Add fluo2 preview option

### DIFF
--- a/backend/app/CellDBConsole/crud.py
+++ b/backend/app/CellDBConsole/crud.py
@@ -1791,7 +1791,14 @@ class CellCrudBase:
         self,
         label: str = "1",
         image_size: int = 200,
-        mode: Literal["fluo", "ph", "ph_conotour", "fluo_contour"] = "fluo",
+        mode: Literal[
+            "fluo",
+            "ph",
+            "ph_contour",
+            "fluo_contour",
+            "fluo2",
+            "fluo2_contour",
+        ] = "fluo",
     ):
         async def combine_images_from_folder(
             folder_path, total_rows, total_cols, image_size
@@ -1853,6 +1860,23 @@ class CellCrudBase:
                                 thickness=3,
                             )
                         )
+                    elif mode == "fluo2":
+                        if cell.img_fluo2 is not None:
+                            await f.write(cell.img_fluo2)
+                        else:
+                            continue
+                    elif mode == "fluo2_contour":
+                        if cell.img_fluo2 is not None:
+                            await f.write(
+                                await CellCrudBase.parse_image_to_bytes(
+                                    cell.img_fluo2,
+                                    cell.contour,
+                                    scale_bar=False,
+                                    thickness=3,
+                                )
+                            )
+                        else:
+                            continue
 
             return StreamingResponse(
                 await combine_images_from_folder(

--- a/backend/app/CellDBConsole/router.py
+++ b/backend/app/CellDBConsole/router.py
@@ -459,7 +459,14 @@ async def download_db(db_name: str):
 async def get_cell_images_combined(
     db_name: str,
     label: Literal["N/A", "1", "2", "3"] = "1",
-    mode: Literal["fluo", "ph", "ph_contour", "fluo_contour"] = "fluo",
+    mode: Literal[
+        "fluo",
+        "ph",
+        "ph_contour",
+        "fluo_contour",
+        "fluo2",
+        "fluo2_contour",
+    ] = "fluo",
 ):
     await AsyncChores().validate_database_name(db_name)
     return await CellCrudBase(db_name=db_name).get_cell_images_combined(

--- a/frontend/src/components/Databases.tsx
+++ b/frontend/src/components/Databases.tsx
@@ -609,9 +609,9 @@ const Databases: React.FC = () => {
                             <MenuItem value="fluo">Fluo</MenuItem>
                             <MenuItem value="ph">Ph</MenuItem>
                             <MenuItem value="ph_contour">Ph + contour</MenuItem>
-                            <MenuItem value="fluo_contour">
-                              Fluo + contour
-                            </MenuItem>
+                            <MenuItem value="fluo_contour">Fluo + contour</MenuItem>
+                            <MenuItem value="fluo2">fluo2</MenuItem>
+                            <MenuItem value="fluo2_contour">fluo2 + contour</MenuItem>
                           </Select>
                           <Select
                             value={selectedLabel}


### PR DESCRIPTION
## Summary
- include fluo2 options when previewing combined images in the DB console
- extend backend API to accept `fluo2` and `fluo2_contour`
- support fluo2 image generation when creating preview images

## Testing
- `./run_tests.sh` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68524d7b7958832d95998f1b8b2fabba