### PR TITLE
Add combined replot preview

### DIFF
--- a/backend/app/CellDBConsole/crud.py
+++ b/backend/app/CellDBConsole/crud.py
@@ -1798,6 +1798,7 @@ class CellCrudBase:
             "fluo_contour",
             "fluo2",
             "fluo2_contour",
+            "replot",
         ] = "fluo",
     ):
         async def combine_images_from_folder(
@@ -1877,7 +1878,14 @@ class CellCrudBase:
                             )
                         else:
                             continue
-
+                    elif mode == "replot":
+                        buf = await AsyncChores.replot(
+                            cell.img_fluo1,
+                            cell.contour,
+                            3,
+                        )
+                        await f.write(buf.getvalue())
+                    
             return StreamingResponse(
                 await combine_images_from_folder(
                     tmp_folder, total_rows, total_cols, image_size

--- a/backend/app/CellDBConsole/router.py
+++ b/backend/app/CellDBConsole/router.py
@@ -466,6 +466,7 @@ async def get_cell_images_combined(
         "fluo_contour",
         "fluo2",
         "fluo2_contour",
+        "replot",
     ] = "fluo",
 ):
     await AsyncChores().validate_database_name(db_name)

--- a/frontend/src/components/Databases.tsx
+++ b/frontend/src/components/Databases.tsx
@@ -612,6 +612,7 @@ const Databases: React.FC = () => {
                             <MenuItem value="fluo_contour">Fluo + contour</MenuItem>
                             <MenuItem value="fluo2">fluo2</MenuItem>
                             <MenuItem value="fluo2_contour">fluo2 + contour</MenuItem>
+                            <MenuItem value="replot">replot</MenuItem>
                           </Select>
                           <Select
                             value={selectedLabel}


### PR DESCRIPTION
## Summary
- allow `replot` mode on combined image endpoint
- show `replot` option in DB list preview

## Testing
- `./run_tests.sh` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6853ea852038832d88b3719caa527da6