### PR TITLE
Add label sorting page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,6 +17,7 @@ import TimelapseDatabases from "./components/TimelapseDatabases";
 import TimelapseViewer from "./components/TimelapseCellOverview";
 import Login from "./components/Login";
 import UserInfo from "./components/Userinfo";
+import LabelSorter from "./components/LabelSorter";
 // ↑ 必要なコンポーネントをインポート
 
 /* --------------------------------
@@ -104,6 +105,14 @@ function App() {
               element={
                 <Box component="main" sx={{ p: 1 }}>
                   <CellImageGrid />
+                </Box>
+              }
+            />
+            <Route
+              path="/labelsorter"
+              element={
+                <Box component="main" sx={{ p: 1 }}>
+                  <LabelSorter />
                 </Box>
               }
             />

--- a/frontend/src/components/Databases.tsx
+++ b/frontend/src/components/Databases.tsx
@@ -412,6 +412,13 @@ const Databases: React.FC = () => {
   };
 
   /**
+   * ラベルソーターページへ遷移
+   */
+  const handleNavigateLabelSorter = (dbName: string) => {
+    navigate(`/labelsorter?db_name=${dbName}`);
+  };
+
+  /**
    * 通常のダイアログを閉じる
    */
   const handleCloseDialog = () => {
@@ -792,6 +799,12 @@ const Databases: React.FC = () => {
                         <TableCell align="right">
                           <IconButton onClick={() => handleNavigate(database)}>
                             <Typography>Access database </Typography>
+                            <NavigateNextIcon />
+                          </IconButton>
+                        </TableCell>
+                        <TableCell align="right">
+                          <IconButton onClick={() => handleNavigateLabelSorter(database)}>
+                            <Typography>Sort labels </Typography>
                             <NavigateNextIcon />
                           </IconButton>
                         </TableCell>

--- a/frontend/src/components/LabelSorter.tsx
+++ b/frontend/src/components/LabelSorter.tsx
@@ -1,0 +1,133 @@
+import React, { useEffect, useState } from "react";
+import { Container, Grid, Typography, Box } from "@mui/material";
+import axios from "axios";
+import { useSearchParams } from "react-router-dom";
+import { settings } from "../settings";
+
+const url_prefix = settings.url_prefix;
+
+const LabelSorter: React.FC = () => {
+  const [searchParams] = useSearchParams();
+  const dbName = searchParams.get("db_name") ?? "";
+
+  const [naCells, setNaCells] = useState<string[]>([]);
+  const [label1Cells, setLabel1Cells] = useState<string[]>([]);
+  const [images, setImages] = useState<{ [key: string]: string }>({});
+
+  useEffect(() => {
+    const fetchCellIds = async () => {
+      try {
+        const naRes = await axios.get(`${url_prefix}/cells/${dbName}/1000`);
+        setNaCells(naRes.data.map((c: { cell_id: string }) => c.cell_id));
+        const label1Res = await axios.get(`${url_prefix}/cells/${dbName}/1`);
+        setLabel1Cells(label1Res.data.map((c: { cell_id: string }) => c.cell_id));
+      } catch (error) {
+        console.error("Failed to fetch cell ids", error);
+      }
+    };
+    if (dbName) fetchCellIds();
+  }, [dbName]);
+
+  useEffect(() => {
+    const fetchImages = async (cellIds: string[]) => {
+      await Promise.all(
+        cellIds.map(async (id) => {
+          if (!images[id]) {
+            try {
+              const res = await axios.get(
+                `${url_prefix}/cells/${id}/${dbName}/true/false/ph_image`,
+                { responseType: "blob" }
+              );
+              const url = URL.createObjectURL(res.data);
+              setImages((prev) => ({ ...prev, [id]: url }));
+            } catch (err) {
+              console.error("Failed to fetch image", err);
+            }
+          }
+        })
+      );
+    };
+    fetchImages(naCells);
+  }, [naCells, dbName, images]);
+
+  useEffect(() => {
+    const fetchImages = async (cellIds: string[]) => {
+      await Promise.all(
+        cellIds.map(async (id) => {
+          if (!images[id]) {
+            try {
+              const res = await axios.get(
+                `${url_prefix}/cells/${id}/${dbName}/true/false/ph_image`,
+                { responseType: "blob" }
+              );
+              const url = URL.createObjectURL(res.data);
+              setImages((prev) => ({ ...prev, [id]: url }));
+            } catch (err) {
+              console.error("Failed to fetch image", err);
+            }
+          }
+        })
+      );
+    };
+    fetchImages(label1Cells);
+  }, [label1Cells, dbName, images]);
+
+  const handleClick = async (cellId: string, fromLabel: "N/A" | "1") => {
+    const newLabel = fromLabel === "N/A" ? "1" : "1000";
+    try {
+      await axios.patch(`${url_prefix}/cells/${dbName}/${cellId}/${newLabel}`);
+      if (fromLabel === "N/A") {
+        setNaCells((prev) => prev.filter((id) => id !== cellId));
+        setLabel1Cells((prev) => [...prev, cellId]);
+      } else {
+        setLabel1Cells((prev) => prev.filter((id) => id !== cellId));
+        setNaCells((prev) => [...prev, cellId]);
+      }
+    } catch (err) {
+      console.error("Failed to update label", err);
+    }
+  };
+
+  const renderCells = (cellIds: string[], label: "N/A" | "1") => (
+    <Grid container spacing={1}>
+      {cellIds.map((id) => (
+        <Grid item xs={4} sm={3} md={2} key={id}>
+          <Box
+            component="img"
+            src={images[id]}
+            alt={id}
+            sx={{ width: "100%", cursor: "pointer" }}
+            onClick={() => handleClick(id, label)}
+          />
+          <Typography variant="caption" display="block" align="center">
+            {id}
+          </Typography>
+        </Grid>
+      ))}
+    </Grid>
+  );
+
+  return (
+    <Container>
+      <Box mb={2}>
+        <Typography variant="h6">Database: {dbName}</Typography>
+      </Box>
+      <Grid container spacing={2}>
+        <Grid item xs={12} md={6}>
+          <Typography variant="h6" gutterBottom>
+            N/A
+          </Typography>
+          {renderCells(naCells, "N/A")}
+        </Grid>
+        <Grid item xs={12} md={6}>
+          <Typography variant="h6" gutterBottom>
+            Label 1
+          </Typography>
+          {renderCells(label1Cells, "1")}
+        </Grid>
+      </Grid>
+    </Container>
+  );
+};
+
+export default LabelSorter;


### PR DESCRIPTION
## Summary
- add new LabelSorter page for adjusting labels visually
- connect new page from the database console
- route `/labelsorter` in the app

## Testing
- `./run_tests.sh` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6853f350be10832da21bf715bba91a5a