### PR TITLE
Fix Sort Labels page width

### DIFF
--- a/frontend/src/components/LabelSorter.tsx
+++ b/frontend/src/components/LabelSorter.tsx
@@ -150,7 +150,7 @@ const LabelSorter: React.FC = () => {
   );
 
   return (
-    <Container>
+    <Container maxWidth={false} disableGutters>
       <Box mb={2}>
         <Breadcrumbs aria-label="breadcrumb">
           <Link underline="hover" color="inherit" href="/">


### PR DESCRIPTION
## Summary
- expand Sort Labels page to full width

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68591f4fa148832dadbbcb0d98f493a8