### PR TITLE
Fix misaligned header on LabelSorter page

### DIFF
--- a/frontend/src/components/LabelSorter.tsx
+++ b/frontend/src/components/LabelSorter.tsx
@@ -181,9 +181,9 @@ const LabelSorter: React.FC = () => {
       <Grid container spacing={2}>
         <Grid item xs={12} md={6}>
           <Box border={1} borderColor="divider" borderRadius={1} p={1} height="100%">
-            <Typography variant="h6" gutterBottom>
-              N/A
-            </Typography>
+          <Typography variant="h6" mb={1}>
+            N/A
+          </Typography>
             {renderCells(naCells, "N/A")}
           </Box>
         </Grid>


### PR DESCRIPTION
## Summary
- adjust spacing on the N/A card header so images align with the labeled side

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685956a07e64832dad2ef45b5625102a