### PR TITLE
Add quick access icons for Cell Extraction and DB console

### DIFF
--- a/frontend/src/components/Nav.tsx
+++ b/frontend/src/components/Nav.tsx
@@ -15,6 +15,8 @@ import Toolbar from '@mui/material/Toolbar';
 import Typography from '@mui/material/Typography';
 import GitHubIcon from '@mui/icons-material/GitHub';
 import AccountCircle from '@mui/icons-material/AccountCircle';
+import ScienceIcon from '@mui/icons-material/Science';
+import DatabaseIcon from '@mui/icons-material/Storage';
 import { settings } from '../settings';
 
 interface Props {
@@ -94,6 +96,20 @@ export default function Nav(props: Props) {
                     </Link>
                     {/* ロゴと右側アイコン群の間にスペーサーを配置 */}
                     <Box sx={{ flexGrow: 1 }} />
+                    <IconButton
+                        color="inherit"
+                        onClick={() => navigate('/nd2files')}
+                        sx={{ color: '#000' }}
+                    >
+                        <ScienceIcon />
+                    </IconButton>
+                    <IconButton
+                        color="inherit"
+                        onClick={() => navigate('/dbconsole')}
+                        sx={{ color: '#000' }}
+                    >
+                        <DatabaseIcon />
+                    </IconButton>
                     <IconButton
                         color="inherit"
                         component="a"


### PR DESCRIPTION
## Summary
- show shortcuts for Cell Extraction and Database Console in the header

## Testing
- `npm test --prefix frontend --silent -- --watchAll=false` *(fails: react-scripts not found)*
- `bash backend/app/run_tests.sh` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_685975162538832dbd6b4e68a55f56ff