### PR TITLE
Fix Database Console width

### DIFF
--- a/frontend/src/components/Databases.tsx
+++ b/frontend/src/components/Databases.tsx
@@ -459,7 +459,7 @@ const Databases: React.FC = () => {
   );
 
   return (
-    <Container>
+    <Container maxWidth={false} disableGutters>
       {/* パンくずリスト */}
       <Box>
         <Breadcrumbs aria-label="breadcrumb">

--- a/frontend/src/components/TimelapseDatabases.tsx
+++ b/frontend/src/components/TimelapseDatabases.tsx
@@ -201,7 +201,7 @@ const TimelapseDatabases: React.FC = () => {
   };
 
   return (
-    <Container>
+    <Container maxWidth={false} disableGutters>
       {/* ローディングスピナー */}
       <Backdrop
         sx={{ color: "#fff", zIndex: (theme) => theme.zIndex.drawer + 1 }}


### PR DESCRIPTION
## Summary
- make Database Console view span the whole screen

## Testing
- `./run_tests.sh` *(fails: ModuleNotFoundError: No module named 'httpx')*
- `npm test --silent --prefix frontend` *(fails: network access needed)*

------
https://chatgpt.com/codex/tasks/task_e_685979ed82f0832d8545f07ed845f25c