### PR TITLE
Fix database console layout

### DIFF
--- a/frontend/src/components/Databases.tsx
+++ b/frontend/src/components/Databases.tsx
@@ -647,7 +647,9 @@ const Databases: React.FC = () => {
                         </Box>
                       </Box>
                     </TableCell>
-                    <TableCell align="center"></TableCell>
+                    <TableCell align="center">Preview</TableCell>
+                    <TableCell align="center">Access</TableCell>
+                    <TableCell align="center">Sort labels</TableCell>
                   </>
                 )}
                 {displayMode === "Dropbox" && (
@@ -699,8 +701,8 @@ const Databases: React.FC = () => {
                       <TableCell component="th" scope="row">
                         <Tooltip title={database} placement="top">
                           <Typography noWrap>
-                            {database.length > 15
-                              ? `${database.substring(0, 15)}...`
+                            {database.length > 30
+                              ? `${database.substring(0, 30)}...`
                               : database}
                           </Typography>
                         </Tooltip>


### PR DESCRIPTION
## Summary
- allow longer DB names in list (30 chars)
- add headers for preview, access, and sort

## Testing
- `npm test --silent --forceExit --runInBand` *(fails: react-scripts not found)*
- `backend/app/run_tests.sh` *(fails: ModuleNotFoundError: httpx)*

------
https://chatgpt.com/codex/tasks/task_e_68597b7696b0832dae75271354962e03