### PR TITLE
Fix label order in Sort labels panel

### DIFF
--- a/frontend/src/components/LabelSorter.tsx
+++ b/frontend/src/components/LabelSorter.tsx
@@ -128,7 +128,7 @@ const LabelSorter: React.FC = () => {
       await axios.patch(`${url_prefix}/cells/${dbName}/${cellId}/${newLabel}`);
       if (fromLabel === "N/A") {
         setNaCells((prev) => prev.filter((id) => id !== cellId));
-        setLabelCells((prev) => [...prev, cellId]);
+        setLabelCells((prev) => [cellId, ...prev]);
       } else {
         setLabelCells((prev) => prev.filter((id) => id !== cellId));
         setNaCells((prev) => [...prev, cellId]);


### PR DESCRIPTION
## Summary
- update LabelSorter so newly moved cells appear at the top of the list

## Testing
- `npm test --silent --yes` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a16671a68832d8717dcae1158aec3