### PR TITLE
Fix label order in LabelSorter

### DIFF
--- a/frontend/src/components/LabelSorter.tsx
+++ b/frontend/src/components/LabelSorter.tsx
@@ -133,7 +133,7 @@ const LabelSorter: React.FC = () => {
           if (newArr.length === 0) {
             return [cellId];
           }
-          newArr.splice(1, 0, cellId);
+          newArr.splice(0, 0, cellId);
           return newArr;
         });
       } else {


### PR DESCRIPTION
## Summary
- show newly labeled cells at the top of the label panel

## Testing
- `npm test --prefix frontend` *(fails: react-scripts not found)*
- `bash backend/app/testing/test_all.sh` *(fails: ModuleNotFoundError: httpx)*

------
https://chatgpt.com/codex/tasks/task_e_685a1c4aebe4832d8b3c39b3fed75397