### PR TITLE
Fix label order in label sorter

### DIFF
--- a/frontend/src/components/LabelSorter.tsx
+++ b/frontend/src/components/LabelSorter.tsx
@@ -128,14 +128,7 @@ const LabelSorter: React.FC = () => {
       await axios.patch(`${url_prefix}/cells/${dbName}/${cellId}/${newLabel}`);
       if (fromLabel === "N/A") {
         setNaCells((prev) => prev.filter((id) => id !== cellId));
-        setLabelCells((prev) => {
-          const newArr = [...prev];
-          if (newArr.length === 0) {
-            return [cellId];
-          }
-          newArr.splice(0, 0, cellId);
-          return newArr;
-        });
+        setLabelCells((prev) => [...prev, cellId]);
       } else {
         setLabelCells((prev) => prev.filter((id) => id !== cellId));
         setNaCells((prev) => [...prev, cellId]);


### PR DESCRIPTION
## Summary
- fix order of newly selected cells when sorting labels

## Testing
- `bash backend/app/run_tests.sh` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_685a1d67a748832db000886302014117