### PR TITLE
Implement CDT analysis feature

### DIFF
--- a/backend/app/CDT/crud.py
+++ b/backend/app/CDT/crud.py
@@ -1,0 +1,76 @@
+import asyncio
+from dataclasses import dataclass
+from typing import List
+import numpy as np
+
+
+@dataclass
+class DataResponse:
+    filename: str
+    mean_length: float
+    nagg_rate: float
+
+
+class CdtCrudBase:
+    """CRUD utilities for CDT analysis."""
+
+    ctrl_value: float | None = None
+
+    @staticmethod
+    def _parse_ctrl(text: str) -> float:
+        ys_1 = [
+            [float(x) for x in line.split(',') if x]
+            for line in text.strip().splitlines()
+            if line.strip()
+        ]
+        ys_norm: list[list[float]] = []
+        for arr in ys_1:
+            a = np.array(arr)
+            if a.max() - a.min() != 0:
+                a = (a - a.min()) / (a.max() - a.min())
+            ys_norm.append(a.tolist())
+        data = [float(np.sum(i) / len(i)) for i in ys_norm]
+        data.sort(reverse=True)
+        if not data:
+            return 0.0
+        index = int(len(data) * 0.95)
+        return data[index]
+
+    @staticmethod
+    def _analyze_csv(text: str, ctrl: float) -> tuple[float, float]:
+        lines = [line.strip() for line in text.strip().splitlines() if line.strip()]
+        cells: list[tuple[float, float]] = []
+        for i in range(0, len(lines), 2):
+            l = lines[i].split(',')[:-1]
+            if len([j for j in l if j != ""]) != 35:
+                continue
+            length = round((float(l[-1]) - float(l[0])) * 0.065, 2)
+            peak_points = np.array([float(x) for x in lines[i + 1].split(',') if x.strip()])
+            if peak_points.max() - peak_points.min() != 0:
+                peak_points = (peak_points - peak_points.min()) / (
+                    peak_points.max() - peak_points.min()
+                )
+            peak_data = float(np.sum(peak_points) / len(peak_points))
+            cells.append((length, peak_data))
+        if not cells:
+            return 0.0, 0.0
+        c = sum(1 for _, p in cells if p < ctrl)
+        nagg_rate = c / len(cells)
+        mean_length = float(np.mean([l for l, _ in cells]))
+        return mean_length, nagg_rate
+
+    @classmethod
+    async def set_ctrl(cls, file_content: bytes) -> None:
+        cls.ctrl_value = await asyncio.to_thread(cls._parse_ctrl, file_content.decode())
+
+    @classmethod
+    async def analyze_files(cls, files: List[tuple[str, bytes]]) -> List[DataResponse]:
+        if cls.ctrl_value is None:
+            raise ValueError("Control data not set")
+        results: List[DataResponse] = []
+        for name, content in files:
+            mean_length, nagg_rate = await asyncio.to_thread(
+                cls._analyze_csv, content.decode(), cls.ctrl_value
+            )
+            results.append(DataResponse(filename=name, mean_length=mean_length, nagg_rate=nagg_rate))
+        return results

--- a/backend/app/CDT/router.py
+++ b/backend/app/CDT/router.py
@@ -1,0 +1,18 @@
+from fastapi import APIRouter, UploadFile
+from fastapi.responses import JSONResponse
+from CDT.crud import CdtCrudBase
+from typing import List
+
+router_cdt = APIRouter(prefix="/cdt", tags=["cdt"])
+
+
+@router_cdt.post("/nagg")
+async def calc_nagg(ctrl_file: UploadFile, files: List[UploadFile]):
+    ctrl_content = await ctrl_file.read()
+    await CdtCrudBase.set_ctrl(ctrl_content)
+    file_contents = []
+    for f in files:
+        content = await f.read()
+        file_contents.append((f.filename, content))
+    results = await CdtCrudBase.analyze_files(file_contents)
+    return JSONResponse(content=[r.__dict__ for r in results])

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -12,6 +12,7 @@ from CellExtraction.router import router_cell_extraction
 from Dev.router import router_dev
 from Dropbox.router import router_dropbox
 from GraphEngine.router import router_graphengine
+from CDT.router import router_cdt
 from TimeLapseEngine.router import router_tl_engine
 from results.router import router_results
 from Auth.router import router_auth
@@ -144,6 +145,7 @@ app.include_router(router_cell_ai, prefix=api_prefix)
 app.include_router(router_tl_engine, prefix=api_prefix)
 app.include_router(router_dropbox, prefix=api_prefix)
 app.include_router(router_graphengine, prefix=api_prefix)
+app.include_router(router_cdt, prefix=api_prefix)
 app.include_router(router_results, prefix=api_prefix)
 app.include_router(router_oauth2, prefix=api_prefix)
 

--- a/backend/app/testing/cdt/conftest.py
+++ b/backend/app/testing/cdt/conftest.py
@@ -1,0 +1,19 @@
+import pytest
+from httpx import AsyncClient, ASGITransport
+from main import app
+
+
+@pytest.fixture(scope="session")
+def anyio_backend():
+    """
+    See https://anyio.readthedocs.io/en/stable/testing.html#using-async-fixtures-with-higher-scopes
+    """
+    return "asyncio"
+
+
+@pytest.fixture(scope="session")
+async def client():
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://testserver"
+    ) as client:
+        yield client

--- a/backend/app/testing/cdt/test_cdt.py
+++ b/backend/app/testing/cdt/test_cdt.py
@@ -1,0 +1,19 @@
+import pytest
+from httpx import AsyncClient
+from unittest.mock import patch
+
+
+@pytest.mark.anyio
+async def test_cdt_nagg(client: AsyncClient):
+    with patch("CDT.crud.CdtCrudBase.set_ctrl", return_value=None), patch(
+        "CDT.crud.CdtCrudBase.analyze_files",
+        return_value=[{"filename": "sample.csv", "mean_length": 1.0, "nagg_rate": 0.5}],
+    ):
+        files = [
+            ("ctrl_file", ("ctrl.csv", "ctrl")),
+            ("files", ("sample.csv", "sample")),
+        ]
+        response = await client.post("/api/cdt/nagg", files=files)
+        assert response.status_code == 200
+        data = response.json()
+        assert data[0]["filename"] == "sample.csv"

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -18,6 +18,7 @@ import TimelapseViewer from "./components/TimelapseCellOverview";
 import Login from "./components/Login";
 import UserInfo from "./components/Userinfo";
 import LabelSorter from "./components/LabelSorter";
+import CDT from "./components/CDT";
 // ↑ 必要なコンポーネントをインポート
 
 /* --------------------------------
@@ -138,6 +139,14 @@ function App() {
                 // Navが確保した余白をさらに詰めるなら p:1 など少なめに設定
                 <Box component="main" sx={{ p: 1 }}>
                   <GraphEngine />
+                </Box>
+              }
+            />
+            <Route
+              path="/cdt"
+              element={
+                <Box component="main" sx={{ p: 1 }}>
+                  <CDT />
                 </Box>
               }
             />

--- a/frontend/src/components/CDT.tsx
+++ b/frontend/src/components/CDT.tsx
@@ -1,0 +1,105 @@
+import React, { useState } from "react";
+import {
+  Box,
+  Container,
+  Breadcrumbs,
+  Link,
+  Typography,
+  Button,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Paper,
+} from "@mui/material";
+import axios from "axios";
+import { settings } from "../settings";
+
+const url_prefix = settings.url_prefix;
+
+interface ResultItem {
+  filename: string;
+  mean_length: number;
+  nagg_rate: number;
+}
+
+const CDT: React.FC = () => {
+  const [ctrlFile, setCtrlFile] = useState<File | null>(null);
+  const [files, setFiles] = useState<FileList | null>(null);
+  const [results, setResults] = useState<ResultItem[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleCtrlChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.files?.length) setCtrlFile(e.target.files[0]);
+  };
+
+  const handleFilesChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.files?.length) setFiles(e.target.files);
+  };
+
+  const handleAnalyze = async () => {
+    if (!ctrlFile || !files?.length) {
+      alert("Please select files");
+      return;
+    }
+    setIsLoading(true);
+    const formData = new FormData();
+    formData.append("ctrl_file", ctrlFile);
+    for (let i = 0; i < files.length; i++) {
+      formData.append("files", files[i]);
+    }
+    try {
+      const res = await axios.post<ResultItem[]>(`${url_prefix}/cdt/nagg`, formData);
+      setResults(res.data);
+    } catch (err) {
+      console.error(err);
+      alert("Failed to analyze files.");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <Container sx={{ py: 4 }}>
+      <Breadcrumbs aria-label="breadcrumb">
+        <Link underline="hover" color="inherit" href="/">
+          Top
+        </Link>
+        <Typography color="text.primary">CDT</Typography>
+      </Breadcrumbs>
+      <Box mt={2} display="flex" flexDirection="column" gap={2}>
+        <input type="file" accept=".csv" onChange={handleCtrlChange} />
+        <input type="file" accept=".csv" multiple onChange={handleFilesChange} />
+        <Button variant="contained" onClick={handleAnalyze} disabled={isLoading}>
+          Analyze
+        </Button>
+      </Box>
+      {results.length > 0 && (
+        <TableContainer component={Paper} sx={{ mt: 4 }}>
+          <Table>
+            <TableHead>
+              <TableRow>
+                <TableCell>Filename</TableCell>
+                <TableCell>Mean Length</TableCell>
+                <TableCell>Nagg Rate</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {results.map((r, idx) => (
+                <TableRow key={idx}>
+                  <TableCell>{r.filename}</TableCell>
+                  <TableCell>{r.mean_length.toFixed(2)}</TableCell>
+                  <TableCell>{(r.nagg_rate * 100).toFixed(2)}%</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      )}
+    </Container>
+  );
+};
+
+export default CDT;

--- a/frontend/src/components/TopPage.tsx
+++ b/frontend/src/components/TopPage.tsx
@@ -274,11 +274,11 @@ const MenuGrid: React.FC<MenuGridProps> = ({ handleNavigate }) => {
         external: false,
       },
       {
-        title: "Swagger UI",
+        title: "CDT",
         icon: <TerminalIcon sx={{ fontSize: 50 }} />,
-        path: `${settings.url_prefix}/docs`,
-        description: "Test the API endpoints.",
-        external: true,
+        path: "/cdt",
+        description: "Calculate nagg from CSV files.",
+        external: false,
       },
       {
         title: "Github",


### PR DESCRIPTION
## Summary
- add CDT backend module for nagg analysis
- expose `/cdt/nagg` endpoint
- add frontend CDT component with file upload UI
- add CDT route and card; remove Swagger card from top page
- include CDT router in FastAPI app
- add minimal tests for new endpoint

## Testing
- `bash backend/app/run_tests.sh` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_685a3d02eba8832da95ba748c6ba0f61