### PR TITLE
Fix KeyError when clearing heatmap plots

### DIFF
--- a/backend/app/GraphEngine/crud.py
+++ b/backend/app/GraphEngine/crud.py
@@ -65,9 +65,9 @@ class SyncChores:
         ax.set_ylabel("Cell length (px)")
         ax.set_xlabel("Cell number")
         buf = io.BytesIO()
-        plt.savefig(buf, format="png", dpi=500)
+        fig.savefig(buf, format="png", dpi=500)
         buf.seek(0)
-        plt.clf()
+        plt.close(fig)
 
         return buf
 
@@ -121,9 +121,9 @@ class SyncChores:
         ax.set_xlabel("Cell number")
 
         buf = io.BytesIO()
-        plt.savefig(buf, format="png", dpi=500)
+        fig.savefig(buf, format="png", dpi=500)
         buf.seek(0)
-        plt.clf()
+        plt.close(fig)
 
         return buf
 


### PR DESCRIPTION
## Summary
- close matplotlib figures directly after saving instead of using `plt.clf`

## Testing
- `bash backend/app/run_tests.sh` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_685a4a686b24832dbcbf1029cab69577