### PR TITLE
Fix LaTeX rendering for Nagg Rate section

### DIFF
--- a/README.md
+++ b/README.md
@@ -751,23 +751,51 @@ Fig. 12-3 staked heatmap with absolute cell lengths. (in µm)
 To compute the "Nagg rate," describing the fraction of cells whose fluorescence falls below a threshold derived from control data.
 
 ### Methodologies:
-1. **Control Threshold**  
+1. **Control Threshold**
+
    Each control trace $\mathbf{Y}_i=(y_{i1},\dots,y_{im})$ is min&ndash;max normalized
-   $$\tilde{y}_{ij}=\frac{y_{ij}-\min_j y_{ij}}{\max_j y_{ij}-\min_j y_{ij}}.$$
+
+   $$
+   \tilde{y}_{ij}=\frac{y_{ij}-\min_j y_{ij}}{\max_j y_{ij}-\min_j y_{ij}}
+   $$
+
    Its mean intensity is
-   $$\bar{y}_i=\frac{1}{m}\sum_{j=1}^m \tilde{y}_{ij}.$$
+
+   $$
+   \bar{y}_i=\frac{1}{m}\sum_{j=1}^m \tilde{y}_{ij}
+   $$
+
    The threshold $C$ equals the 95th percentile of $\{\bar{y}_i\}$.
-2. **Sample Evaluation**  
+
+2. **Sample Evaluation**
+
    A sample cell provides positions $(x_{i1},\ldots,x_{i35})$ and peaks $\mathbf{S}_i=(s_{i1},\dots,s_{im})$. Its length is
-   $$L_i=(x_{i35}-x_{i1})\times0.065.$$
+
+   $$
+   L_i=(x_{i35}-x_{i1})\times 0.065
+   $$
+
    After normalizing
-   $$\tilde{s}_{ij}=\frac{s_{ij}-\min_j s_{ij}}{\max_j s_{ij}-\min_j s_{ij}},$$
+
+   $$
+   \tilde{s}_{ij}=\frac{s_{ij}-\min_j s_{ij}}{\max_j s_{ij}-\min_j s_{ij}}
+   $$
+
    we compute
-   $$\bar{s}_i=\frac{1}{m}\sum_{j=1}^m \tilde{s}_{ij}.$$
-   Cells with $\bar{s}_i<C$ are counted.
-3. **Rate Calculation**  
+
+   $$
+   \bar{s}_i=\frac{1}{m}\sum_{j=1}^m \tilde{s}_{ij}
+   $$
+
+   Cells with $\bar{s}_i < C$ are counted.
+
+3. **Rate Calculation**
+
    For $N$ cells we obtain
-   $$R=\frac{\#\{i\mid\bar{s}_i<C\}}{N},\qquad \bar{L}=\frac{1}{N}\sum_{i=1}^N L_i.$$
+
+   $$
+   R=\frac{\#\{i\mid\bar{s}_i<C\}}{N},\qquad \bar{L}=\frac{1}{N}\sum_{i=1}^N L_i.
+   $$
 
 ### Result:
 The API returns $(\bar{L},R)$ for each analyzed file.


### PR DESCRIPTION
## Summary
- format the Nagg Rate algorithm equations in README so GitHub displays them as LaTeX

## Testing
- `./test_all.sh` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_685b96983a10832d85d1a592699f9509