### PR TITLE
Add quad-layer option to cell extraction

### DIFF
--- a/backend/app/CellExtraction/router.py
+++ b/backend/app/CellExtraction/router.py
@@ -61,7 +61,11 @@ async def delete_nd2_file(file_name: str):
 async def extract_cells(
     db_name: str,
     mode: Literal[
-        "single_layer", "dual_layer", "triple_layer", "dual_layer_reversed"
+        "single_layer",
+        "dual_layer",
+        "triple_layer",
+        "quad_layer",
+        "dual_layer_reversed",
     ] = "dual",
     param1: int = 100,
     image_size: int = 200,

--- a/frontend/src/components/CellExtraction.tsx
+++ b/frontend/src/components/CellExtraction.tsx
@@ -229,6 +229,7 @@ const Extraction: React.FC = () => {
                 <MenuItem value="dual_layer">Dual Layer</MenuItem>
                 <MenuItem value="dual_layer_reversed">Dual Layer (Reversed)</MenuItem>
                 <MenuItem value="triple_layer">Triple Layer</MenuItem>
+                <MenuItem value="quad_layer">Quad Layer</MenuItem>
               </Select>
             </FormControl>
 


### PR DESCRIPTION
## Summary
- allow specifying `quad_layer` when extracting cells
- skip saving fluo3 channel but parse 4-channel ND2 files
- expose the new mode in the API and frontend

## Testing
- `bash backend/app/run_tests.sh` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_685d2bd302d0832db718a081e1475c03