### PR TITLE
Add filename sanitization for ND2 uploads

### DIFF
--- a/backend/app/CellExtraction/crud.py
+++ b/backend/app/CellExtraction/crud.py
@@ -161,7 +161,9 @@ class SyncChores:
     def extract_tiff(
         tiff_path: str,
         ulid: str,
-        mode: Literal["single_layer", "dual_layer", "triple_layer", "quad_layer"] = "dual_layer",
+        mode: Literal[
+            "single_layer", "dual_layer", "triple_layer", "quad_layer"
+        ] = "dual_layer",
         reverse: bool = False,
     ) -> int:
         temp_dir = f"TempData{ulid}"
@@ -437,7 +439,9 @@ class ExtractionCrudBase:
     ):
         self.nd2_path = nd2_path
         self.nd2_path = self.nd2_path.replace("\\", "/")
-        self.file_prefix = self.nd2_path.split("/")[-1].split(".")[0]
+        basename = os.path.basename(self.nd2_path)
+        base, _ = os.path.splitext(basename)
+        self.file_prefix = base.replace(".", "p")
         self.mode = mode
         self.param1 = param1
         self.image_size = image_size

--- a/backend/app/CellExtraction/router.py
+++ b/backend/app/CellExtraction/router.py
@@ -30,15 +30,17 @@ async def get_ph_contours(frame_num: int, session_ulid: str):
 
 @router_cell_extraction.post("/nd2_files")
 async def upload_nd2_file(file: UploadFile):
-    file_path = file.filename
-    file_path = os.path.join("uploaded_files", file_path)
+    filename = os.path.basename(file.filename)
+    base, ext = os.path.splitext(filename)
+    sanitized = base.replace(".", "p") + ext
+    file_path = os.path.join("uploaded_files", sanitized)
     try:
         async with aiofiles.open(file_path, "wb") as out_file:
             while content := await file.read(1024 * 1024 * 100):
                 await out_file.write(content)
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
-    return JSONResponse(content={"filename": file.filename})
+    return JSONResponse(content={"filename": sanitized})
 
 
 @router_cell_extraction.get("/nd2_files")


### PR DESCRIPTION
## Summary
- sanitize ND2 file names on upload
- update file prefix logic to handle dots
- sanitize file names when creating cell databases

## Testing
- `backend/app/run_tests.sh` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_685d308d33f8832db3d07aa420dc3cfa