### PR TITLE
Use SVM model when autolabeling

### DIFF
--- a/backend/app/AutoLabel/crud.py
+++ b/backend/app/AutoLabel/crud.py
@@ -8,8 +8,7 @@ import numpy as np
 from CellDBConsole.crud import CellCrudBase
 
 ROOT_DIR = Path(__file__).resolve().parents[2]
-MODEL_PATH = "AutoLabel/autolabel_lda.joblib"
-THRESHOLD =  -4.875273
+MODEL_PATH = "AutoLabel/svm_cell_classifier.pkl"
 
 
 class AutoLabelCrud:
@@ -32,21 +31,28 @@ class AutoLabelCrud:
         new_x = np.linspace(0.0, 1.0, target_len)
         return np.interp(new_x, old_x, vec)
 
-    async def embed_contour(self, contour: List[List[float]]) -> float:
+    async def predict_label(self, contour: List[List[float]]) -> str:
+        """Predict label for a contour using the loaded SVM model."""
         np_contour = np.array(contour)
         loop = asyncio.get_running_loop()
         with ThreadPoolExecutor() as executor:
-            vec = await loop.run_in_executor(executor, self.contour_to_vector, np_contour)
-            resampled = await loop.run_in_executor(executor, self.resample_vector, vec)
-            emb = await loop.run_in_executor(executor, self.model.transform, resampled.reshape(1, -1))
-        return float(emb[0, 0])
+            vec = await loop.run_in_executor(
+                executor, self.contour_to_vector, np_contour
+            )
+            resampled = await loop.run_in_executor(
+                executor, self.resample_vector, vec
+            )
+            label = await loop.run_in_executor(
+                executor,
+                self.model.predict,
+                resampled.reshape(1, -1),
+            )
+        return str(label[0])
 
     async def autolabel(self) -> None:
+        """Automatically label all cells marked as "N/A" using the SVM model."""
         na_ids = await CellCrudBase(self.db_name).read_cell_ids(label="N/A")
         for cell in na_ids:
             contour = await CellCrudBase(self.db_name).get_cell_contour(cell.cell_id)
-            emb = await self.embed_contour(contour)
-            if emb <= THRESHOLD:
-                await CellCrudBase(self.db_name).update_label(cell.cell_id, "1")
-            else:
-                await CellCrudBase(self.db_name).update_label(cell.cell_id, "N/A")
+            label = await self.predict_label(contour)
+            await CellCrudBase(self.db_name).update_label(cell.cell_id, label)


### PR DESCRIPTION
## Summary
- switch autolabel crud to use `svm_cell_classifier.pkl`
- implement `predict_label` helper
- update autolabel logic to predict labels via SVM model

## Testing
- `backend/app/run_tests.sh` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_685e3302afc4832da54f550f43f0aa30