### PR TITLE
Fix image fetch loops in LabelSorter

### DIFF
--- a/frontend/src/components/LabelSorter.tsx
+++ b/frontend/src/components/LabelSorter.tsx
@@ -120,7 +120,7 @@ const LabelSorter: React.FC = () => {
       );
     };
     fetchImages(naCells);
-  }, [naCells, dbName, channel, images]);
+  }, [naCells, dbName, channel]);
 
   useEffect(() => {
     const fetchImages = async (cellIds: string[]) => {
@@ -149,7 +149,7 @@ const LabelSorter: React.FC = () => {
       );
     };
     fetchImages(labelCells);
-  }, [labelCells, dbName, channel, images]);
+  }, [labelCells, dbName, channel]);
 
   const isLoading =
     !naLoaded ||


### PR DESCRIPTION
## Summary
- stop `useEffect` dependencies from causing repeated network calls

## Testing
- `bash backend/app/run_tests.sh` *(fails: ModuleNotFoundError: No module named 'httpx')*
- `npm test --silent` in `frontend` *(fails: react-scripts: not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e361f2b4c832da043545503ffcd26