### PR TITLE
Fix autolabel model path

### DIFF
--- a/backend/app/AutoLabel/crud.py
+++ b/backend/app/AutoLabel/crud.py
@@ -8,7 +8,7 @@ import numpy as np
 from CellDBConsole.crud import CellCrudBase
 
 ROOT_DIR = Path(__file__).resolve().parents[2]
-MODEL_PATH = "AutoLabel/svm_cell_classifier.pkl"
+MODEL_PATH = Path(__file__).resolve().parent / "svm_cell_classifier.pkl"
 
 
 class AutoLabelCrud:


### PR DESCRIPTION
## Summary
- update `AutoLabelCrud` to use an absolute path for the SVM model

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_685e3886b664832db5cf14d9a8c6ee4f