### PR TITLE
Add Laplacian draw mode

### DIFF
--- a/backend/app/CellDBConsole/router.py
+++ b/backend/app/CellDBConsole/router.py
@@ -260,6 +260,12 @@ async def get_cell_path(
     )
 
 
+@router_cell.get("/{cell_id}/{db_name}/laplacian", response_class=StreamingResponse)
+async def get_cell_laplacian(cell_id: str, db_name: str):
+    await AsyncChores().validate_database_name(db_name)
+    return await CellCrudBase(db_name=db_name).get_laplacian(cell_id)
+
+
 @router_cell.get("/{db_name}/{label}/{cell_id}/mean_fluo_intensities")
 async def get_mean_fluo_intensities(db_name: str, label: str, cell_id: str):
     await AsyncChores().validate_database_name(db_name)

--- a/backend/app/testing/database/test_database.py
+++ b/backend/app/testing/database/test_database.py
@@ -274,6 +274,15 @@ async def test_get_cell_path(client: AsyncClient):
 
 
 @pytest.mark.anyio
+async def test_get_cell_laplacian(client: AsyncClient):
+    """
+    GET /cells/{cell_id}/{db_name}/laplacian
+    """
+    response = await client.get("/api/cells/F0C5/test_database.db/laplacian")
+    assert response.status_code == 200
+
+
+@pytest.mark.anyio
 async def test_get_mean_fluo_intensities(client: AsyncClient):
     """
     GET /cells/{db_name}/{label}/{cell_id}/mean_fluo_intensities

--- a/frontend/src/components/CellOverview.tsx
+++ b/frontend/src/components/CellOverview.tsx
@@ -61,6 +61,7 @@ type ImageState = {
   prediction?: string; // AI推論画像
   cloud_points?: string; // 3D表示
   cloud_points_ph?: string; // 3D PH表示
+  laplacian?: string; // Laplacian画像
 };
 
 // 「どのモードにするか」を列挙型的に管理する
@@ -70,6 +71,7 @@ type DrawModeType =
   | "distribution"
   | "distribution_normalized"
   | "path"
+  | "laplacian"
   | "t1contour"
   | "prediction"
   | "cloud_points"
@@ -115,6 +117,7 @@ const DRAW_MODES: {
   { value: "distribution", label: "Distribution" },
   { value: "distribution_normalized", label: "Distribution (Normalized)" },
   { value: "path", label: "Peak-path", needsPolyfit: true },
+  { value: "laplacian", label: "Laplacian" },
   { value: "t1contour", label: "Light+Model T1" },
   { value: "prediction", label: "Model T1(Torch GPU)" },
   { value: "cloud_points", label: "3D Fluo" },
@@ -349,6 +352,18 @@ const CellImageGrid: React.FC = () => {
             [cellId]: { ...prev[cellId], path: url },
           }));
           setIsLoading(false);
+          break;
+        }
+        case "laplacian": {
+          const response = await axios.get(
+            `${url_prefix}/cells/${cellId}/${db_name}/laplacian`,
+            { responseType: "blob" }
+          );
+          const url = URL.createObjectURL(response.data);
+          setImages((prev) => ({
+            ...prev,
+            [cellId]: { ...prev[cellId], laplacian: url },
+          }));
           break;
         }
         case "prediction": {
@@ -1108,6 +1123,15 @@ const CellImageGrid: React.FC = () => {
                 <img
                   src={images[cellIds[currentIndex]]?.distribution_normalized}
                   alt={`Cell ${cellIds[currentIndex]} Distribution (Normalized)`}
+                  style={{ width: "100%" }}
+                />
+              )}
+
+            {drawMode === "laplacian" &&
+              images[cellIds[currentIndex]]?.laplacian && (
+                <img
+                  src={images[cellIds[currentIndex]]?.laplacian}
+                  alt={`Cell ${cellIds[currentIndex]} Laplacian`}
                   style={{ width: "100%" }}
                 />
               )}


### PR DESCRIPTION
## Summary
- add Laplacian image generator on backend
- expose new /laplacian endpoint
- test for Laplacian endpoint
- support Laplacian draw mode in frontend

## Testing
- `./run_tests.sh` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6861e591b418832d93a0ba8ed327432d