### PR TITLE
Add fluo channel support for Laplacian mode

### DIFF
--- a/backend/app/CellDBConsole/crud.py
+++ b/backend/app/CellDBConsole/crud.py
@@ -2011,13 +2011,12 @@ class CellCrudBase:
         return buf
 
     async def get_laplacian(
-        self, cell_id: str
+        self, cell_id: str, channel: int = 1
     ) -> StreamingResponse:
-        """Return Laplacian filtered PH image with outside masked."""
+        """Return Laplacian filtered fluo image with outside masked."""
         cell = await self.read_cell(cell_id)
-        img = cv2.imdecode(
-            np.frombuffer(cell.img_ph, np.uint8), cv2.IMREAD_GRAYSCALE
-        )
+        img_blob = cell.img_fluo2 if channel == 2 else cell.img_fluo1
+        img = cv2.imdecode(np.frombuffer(img_blob, np.uint8), cv2.IMREAD_GRAYSCALE)
         contour = await AsyncChores.async_pickle_loads(cell.contour)
         mask = np.zeros_like(img)
         cv2.fillPoly(mask, [np.array(contour, dtype=np.int32)], 255)

--- a/backend/app/CellDBConsole/router.py
+++ b/backend/app/CellDBConsole/router.py
@@ -261,9 +261,11 @@ async def get_cell_path(
 
 
 @router_cell.get("/{cell_id}/{db_name}/laplacian", response_class=StreamingResponse)
-async def get_cell_laplacian(cell_id: str, db_name: str):
+async def get_cell_laplacian(
+    cell_id: str, db_name: str, channel: int = 1
+):
     await AsyncChores().validate_database_name(db_name)
-    return await CellCrudBase(db_name=db_name).get_laplacian(cell_id)
+    return await CellCrudBase(db_name=db_name).get_laplacian(cell_id, channel)
 
 
 @router_cell.get("/{db_name}/{label}/{cell_id}/mean_fluo_intensities")

--- a/frontend/src/components/CellOverview.tsx
+++ b/frontend/src/components/CellOverview.tsx
@@ -355,8 +355,9 @@ const CellImageGrid: React.FC = () => {
           break;
         }
         case "laplacian": {
+          const channelParam = fluoChannel === 'fluo2' ? 2 : 1;
           const response = await axios.get(
-            `${url_prefix}/cells/${cellId}/${db_name}/laplacian`,
+            `${url_prefix}/cells/${cellId}/${db_name}/laplacian?channel=${channelParam}`,
             { responseType: "blob" }
           );
           const url = URL.createObjectURL(response.data);


### PR DESCRIPTION
## Summary
- allow selecting fluo1 or fluo2 when drawing Laplacian images
- backend now accepts `channel` query param for Laplacian endpoint
- frontend sends selected channel when requesting Laplacian images

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6861e869dbb0832d8102b3be6a4ced49