### PR TITLE
Add laplacian brightness control

### DIFF
--- a/backend/app/CellDBConsole/crud.py
+++ b/backend/app/CellDBConsole/crud.py
@@ -2011,7 +2011,7 @@ class CellCrudBase:
         return buf
 
     async def get_laplacian(
-        self, cell_id: str, channel: int = 1
+        self, cell_id: str, channel: int = 1, brightness_factor: float = 1.0
     ) -> StreamingResponse:
         """Return Laplacian filtered fluo image with outside masked."""
         cell = await self.read_cell(cell_id)
@@ -2023,6 +2023,8 @@ class CellCrudBase:
         masked = cv2.bitwise_and(img, mask)
         lap = cv2.Laplacian(masked, cv2.CV_64F)
         lap = cv2.convertScaleAbs(lap)
+        if brightness_factor != 1.0:
+            lap = cv2.convertScaleAbs(lap, alpha=brightness_factor, beta=0)
         _, buffer = cv2.imencode(".png", lap)
         buf = io.BytesIO(buffer)
         buf.seek(0)

--- a/backend/app/CellDBConsole/router.py
+++ b/backend/app/CellDBConsole/router.py
@@ -262,10 +262,12 @@ async def get_cell_path(
 
 @router_cell.get("/{cell_id}/{db_name}/laplacian", response_class=StreamingResponse)
 async def get_cell_laplacian(
-    cell_id: str, db_name: str, channel: int = 1
+    cell_id: str, db_name: str, channel: int = 1, brightness_factor: float = 1.0
 ):
     await AsyncChores().validate_database_name(db_name)
-    return await CellCrudBase(db_name=db_name).get_laplacian(cell_id, channel)
+    return await CellCrudBase(db_name=db_name).get_laplacian(
+        cell_id, channel, brightness_factor
+    )
 
 
 @router_cell.get("/{db_name}/{label}/{cell_id}/mean_fluo_intensities")

--- a/backend/app/testing/database/test_database.py
+++ b/backend/app/testing/database/test_database.py
@@ -278,7 +278,9 @@ async def test_get_cell_laplacian(client: AsyncClient):
     """
     GET /cells/{cell_id}/{db_name}/laplacian
     """
-    response = await client.get("/api/cells/F0C5/test_database.db/laplacian")
+    response = await client.get(
+        "/api/cells/F0C5/test_database.db/laplacian?brightness_factor=1.5"
+    )
     assert response.status_code == 200
 
 

--- a/frontend/src/components/CellOverview.tsx
+++ b/frontend/src/components/CellOverview.tsx
@@ -149,6 +149,7 @@ const CellImageGrid: React.FC = () => {
   const [drawScaleBar, setDrawScaleBar] = useState<boolean>(false);
   const [autoPlay, setAutoPlay] = useState<boolean>(false);
   const [brightnessFactor, setBrightnessFactor] = useState<number>(1.0);
+  const [laplacianBrightness, setLaplacianBrightness] = useState<number>(1.0);
   const [hasFluo2, setHasFluo2] = useState<boolean>(false);
   const [fluoChannel, setFluoChannel] = useState<'fluo1' | 'fluo2'>('fluo1');
   const [drawMode, setDrawMode] = useState<DrawModeType>(init_draw_mode);
@@ -357,7 +358,7 @@ const CellImageGrid: React.FC = () => {
         case "laplacian": {
           const channelParam = fluoChannel === 'fluo2' ? 2 : 1;
           const response = await axios.get(
-            `${url_prefix}/cells/${cellId}/${db_name}/laplacian?channel=${channelParam}`,
+            `${url_prefix}/cells/${cellId}/${db_name}/laplacian?channel=${channelParam}&brightness_factor=${laplacianBrightness}`,
             { responseType: "blob" }
           );
           const url = URL.createObjectURL(response.data);
@@ -437,7 +438,7 @@ const CellImageGrid: React.FC = () => {
     const cellId = cellIds[currentIndex];
     fetchAdditionalImage(drawMode, cellId);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [drawMode, cellIds, currentIndex, fitDegree, fluoChannel]);
+  }, [drawMode, cellIds, currentIndex, fitDegree, fluoChannel, laplacianBrightness]);
 
   //------------------------------------
   // 現在のセルIDに対応した初期ラベルを取得
@@ -580,6 +581,11 @@ const CellImageGrid: React.FC = () => {
   };
   const handleBrightnessChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setBrightnessFactor(parseFloat(e.target.value));
+  };
+  const handleLaplacianBrightnessChange = (
+    e: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    setLaplacianBrightness(parseFloat(e.target.value));
   };
   const handleWheel = (event: React.WheelEvent<HTMLDivElement>) => {
     event.currentTarget.blur();
@@ -1089,6 +1095,21 @@ const CellImageGrid: React.FC = () => {
                     <MenuItem value="fluo2">fluo2</MenuItem>
                   </Select>
                 </FormControl>
+              )}
+              {drawMode === "laplacian" && (
+                <TextField
+                  label="Brightness"
+                  variant="outlined"
+                  type="number"
+                  value={laplacianBrightness}
+                  onChange={handleLaplacianBrightnessChange}
+                  InputProps={{
+                    inputProps: { min: 0.1, step: 0.1 },
+                    onWheel: handleWheel,
+                    autoComplete: "off",
+                  }}
+                  sx={{ width: 120 }}
+                />
               )}
             </Box>
 


### PR DESCRIPTION
## Summary
- add brightness_factor to laplacian backend API
- adjust CRUD to apply brightness to Laplacian image
- update React frontend with Laplacian brightness field
- support brightness_factor query when fetching Laplacian
- update tests for new parameter

## Testing
- `bash backend/app/testing/test_all.sh` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6861ecc85eb4832db84ce6f4e34f984d