### PR TITLE
Add AreaFractionEngine for nucleoid analysis

### DIFF
--- a/README_JA.md
+++ b/README_JA.md
@@ -116,6 +116,11 @@
 
     ![](docs_images/27.png)
 
+   `AreaFractionEngine` は HU-GFP 画像から核様体領域の面積比を算出し、他のラベル
+   選択細胞と比較した分布の中で現在の細胞がどこに位置するかを示す。
+
+    ![](docs_images/26.png)
+
     最後に、`HeatmapEngine`で描画されるヒートマップは三次元蛍光輝度情報を長軸ベースに圧縮し、さらにそれを上から見たものになる。
 
     ![](docs_images/28.png)

--- a/Software_Docs.md
+++ b/Software_Docs.md
@@ -148,6 +148,10 @@ If you choose `MedianEngine`, it shows you the normalized median of the pixels i
 
 ![](docs_images/27.png)
 
+`AreaFractionEngine` compares the nucleoid area fraction of the selected cell with other cells sharing the same label and visualizes the position of the current cell within the distribution.
+
+![](docs_images/26.png)
+
 `HeatmapEngine` qualitatively visualizes the localization of the fluorescence at relative positions from the edge of the cell.
 
 ![](docs_images/28.png)

--- a/backend/app/CellDBConsole/router.py
+++ b/backend/app/CellDBConsole/router.py
@@ -315,6 +315,19 @@ async def get_var_fluo_intensities(db_name: str, label: str, cell_id: str):
     return ret
 
 
+@router_cell.get("/{db_name}/{label}/{cell_id}/area_fraction")
+async def get_area_fraction(db_name: str, label: str, cell_id: str):
+    await AsyncChores().validate_database_name(db_name)
+    ret: StreamingResponse = await CellCrudBase(
+        db_name=db_name
+    ).get_all_area_fractions(
+        label=label,
+        cell_id=cell_id,
+        y_label="Nucleoid Area Fraction",
+    )
+    return ret
+
+
 @router_cell.get(
     "/{db_name}/{label}/median_fluo_intensities/csv", response_class=StreamingResponse
 )
@@ -343,6 +356,16 @@ async def get_var_fluo_intensities_csv(db_name: str, label: str):
     return await CellCrudBase(
         db_name=db_name
     ).get_all_variance_normalized_fluo_intensities_csv(label=label)
+
+
+@router_cell.get(
+    "/{db_name}/{label}/area_fraction/csv", response_class=StreamingResponse
+)
+async def get_area_fraction_csv(db_name: str, label: str):
+    await AsyncChores().validate_database_name(db_name)
+    return await CellCrudBase(
+        db_name=db_name
+    ).get_all_area_fractions_csv(label=label)
 
 
 @router_cell.get(

--- a/backend/app/testing/database/test_database.py
+++ b/backend/app/testing/database/test_database.py
@@ -329,6 +329,17 @@ async def test_get_var_fluo_intensities(client: AsyncClient):
 
 
 @pytest.mark.anyio
+async def test_get_area_fraction(client: AsyncClient):
+    """
+    GET /cells/{db_name}/{label}/{cell_id}/area_fraction
+    """
+    response = await client.get(
+        "/api/cells/test_database.db/1/F0C5/area_fraction"
+    )
+    assert response.status_code == 200
+
+
+@pytest.mark.anyio
 async def test_get_median_fluo_intensities_csv(client: AsyncClient):
     """
     GET /cells/{db_name}/{label}/median_fluo_intensities/csv
@@ -357,6 +368,17 @@ async def test_get_var_fluo_intensities_csv(client: AsyncClient):
     """
     response = await client.get(
         "/api/cells/test_database.db/1/var_fluo_intensities/csv"
+    )
+    assert response.status_code == 200
+
+
+@pytest.mark.anyio
+async def test_get_area_fraction_csv(client: AsyncClient):
+    """
+    GET /cells/{db_name}/{label}/area_fraction/csv
+    """
+    response = await client.get(
+        "/api/cells/test_database.db/1/area_fraction/csv"
     )
     assert response.status_code == 200
 

--- a/frontend/src/components/AreaFractionEngine.tsx
+++ b/frontend/src/components/AreaFractionEngine.tsx
@@ -1,0 +1,95 @@
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
+import { Box, CircularProgress, Button } from '@mui/material';
+import { settings } from '../settings';
+import DownloadIcon from '@mui/icons-material/Download';
+
+interface AreaFractionProps {
+    dbName: string;
+    label: string;
+    cellId: string;
+}
+const url_prefix = settings.url_prefix;
+
+const AreaFractionEngine: React.FC<AreaFractionProps> = ({ dbName, label, cellId }) => {
+    const [imageUrl, setImageUrl] = useState<string | null>(null);
+    const [loading, setLoading] = useState<boolean>(false);
+
+    useEffect(() => {
+        const fetchImageData = async () => {
+            setLoading(true);
+            try {
+                const response = await axios.get(
+                    `${url_prefix}/cells/${dbName}/${label}/${cellId}/area_fraction`,
+                    { responseType: 'blob' }
+                );
+                const imageBlobUrl = URL.createObjectURL(response.data);
+                setImageUrl(imageBlobUrl);
+            } catch (error) {
+                console.error('Failed to fetch image data:', error);
+                setImageUrl(null);
+            } finally {
+                setLoading(false);
+            }
+        };
+
+        fetchImageData();
+    }, [dbName, label, cellId]);
+
+    const handleDownloadCsv = async () => {
+        try {
+            const response = await axios.get(
+                `${url_prefix}/cells/${dbName}/${label}/area_fraction/csv`,
+                { responseType: 'blob' }
+            );
+            const url = window.URL.createObjectURL(new Blob([response.data]));
+            const link = document.createElement('a');
+            link.href = url;
+            link.setAttribute('download', `${dbName}_area_fraction.csv`);
+            document.body.appendChild(link);
+            link.click();
+            link?.parentNode?.removeChild(link);
+        } catch (error) {
+            console.error('Failed to download CSV:', error);
+        }
+    };
+
+    if (loading) {
+        return (
+            <Box display="flex" justifyContent="center">
+                <CircularProgress />
+            </Box>
+        );
+    }
+
+    if (!imageUrl) {
+        return <Box>No image available</Box>;
+    }
+
+    return (
+        <Box display="flex" flexDirection="column" alignItems="center">
+            <img
+                src={imageUrl}
+                alt="Area Fraction"
+                style={{ maxWidth: '100%', height: 'auto' }}
+            />
+            <Button
+                variant="contained"
+                onClick={handleDownloadCsv}
+                sx={{
+                    color: 'black',
+                    backgroundColor: '#ffffff',
+                    '&:hover': {
+                        backgroundColor: '#e0e0e0',
+                    },
+                    marginTop: 1,
+                }}
+                startIcon={<DownloadIcon />}
+            >
+                Download CSV
+            </Button>
+        </Box>
+    );
+};
+
+export default AreaFractionEngine;

--- a/frontend/src/components/CellOverview.tsx
+++ b/frontend/src/components/CellOverview.tsx
@@ -26,6 +26,7 @@ import MedianEngine from "./MedianEngine";
 import MeanEngine from "./MeanEngine";
 import HeatmapEngine from "./HeatmapEngine";
 import VarEngine from "./VarEngine";
+import AreaFractionEngine from "./AreaFractionEngine";
 
 import {
   Chart as ChartJS,
@@ -86,7 +87,8 @@ type EngineName =
   | "MedianEngine"
   | "MeanEngine"
   | "HeatmapEngine"
-  | "VarEngine";
+  | "VarEngine"
+  | "AreaFractionEngine";
 
 // MorphoEngineロゴマッピング
 const engineLogos: Record<EngineName, string> = {
@@ -95,6 +97,7 @@ const engineLogos: Record<EngineName, string> = {
   MedianEngine: "/logo_dots.png",
   MeanEngine: "/logo_circular.png",
   VarEngine: "/var_logo.png",
+  AreaFractionEngine: "/logo_cross.png",
   HeatmapEngine: "/logo_heatmap.png",
 };
 
@@ -1389,6 +1392,16 @@ const CellImageGrid: React.FC = () => {
           {engineMode === "VarEngine" && (
             <Box mt={6}>
               <VarEngine
+                dbName={db_name}
+                label={selectedLabel}
+                cellId={cellIds[currentIndex]}
+              />
+            </Box>
+          )}
+
+          {engineMode === "AreaFractionEngine" && (
+            <Box mt={6}>
+              <AreaFractionEngine
                 dbName={db_name}
                 label={selectedLabel}
                 cellId={cellIds[currentIndex]}


### PR DESCRIPTION
## Summary
- implement `calc_area_fraction` to compute nucleoid area fraction
- expose new endpoints to fetch area-fraction boxplots and csv
- integrate AreaFractionEngine component in React frontend
- update docs to mention the new engine
- extend API tests to cover new endpoints

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed: 403 Forbidden)*
- `./run_tests.sh` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68620a109f54832d8216b9342cb0dd74