### PR TITLE
Add HU mask draw mode

### DIFF
--- a/backend/app/CellDBConsole/router.py
+++ b/backend/app/CellDBConsole/router.py
@@ -282,6 +282,12 @@ async def get_cell_sobel(
     )
 
 
+@router_cell.get("/{cell_id}/{db_name}/hu_mask", response_class=StreamingResponse)
+async def get_cell_hu_mask(cell_id: str, db_name: str, channel: int = 1):
+    await AsyncChores().validate_database_name(db_name)
+    return await CellCrudBase(db_name=db_name).get_hu_mask(cell_id, channel)
+
+
 @router_cell.get("/{db_name}/{label}/{cell_id}/mean_fluo_intensities")
 async def get_mean_fluo_intensities(db_name: str, label: str, cell_id: str):
     await AsyncChores().validate_database_name(db_name)

--- a/backend/app/testing/database/test_database.py
+++ b/backend/app/testing/database/test_database.py
@@ -296,6 +296,13 @@ async def test_get_cell_sobel(client: AsyncClient):
 
 
 @pytest.mark.anyio
+async def test_get_cell_hu_mask(client: AsyncClient):
+    """GET /cells/{cell_id}/{db_name}/hu_mask"""
+    response = await client.get("/api/cells/F0C5/test_database.db/hu_mask")
+    assert response.status_code == 200
+
+
+@pytest.mark.anyio
 async def test_get_mean_fluo_intensities(client: AsyncClient):
     """
     GET /cells/{db_name}/{label}/{cell_id}/mean_fluo_intensities


### PR DESCRIPTION
## Summary
- add HU-GFP mask endpoint to backend and wire up router
- display HU mask in CellOverview and allow fluo channel selection
- include regression tests for new endpoint

## Testing
- `bash backend/app/run_tests.sh` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_686224de7f00832dbfe60deeec499f77