### PR TITLE
Add clipped Map64 display

### DIFF
--- a/backend/app/CellDBConsole/router.py
+++ b/backend/app/CellDBConsole/router.py
@@ -316,6 +316,20 @@ async def get_cell_map64_jet(
     )
 
 
+@router_cell.get("/{cell_id}/{db_name}/map64_clip", response_class=StreamingResponse)
+async def get_cell_map64_clip(
+    cell_id: str,
+    db_name: str,
+    degree: int = 4,
+    channel: int = 1,
+    img_type: Literal["fluo", "ph"] = "fluo",
+):
+    await AsyncChores().validate_database_name(db_name)
+    return await CellCrudBase(db_name=db_name).get_map64_clip(
+        cell_id, degree=degree, channel=channel, img_type=img_type
+    )
+
+
 @router_cell.get("/{db_name}/{label}/{cell_id}/mean_fluo_intensities")
 async def get_mean_fluo_intensities(db_name: str, label: str, cell_id: str):
     await AsyncChores().validate_database_name(db_name)

--- a/frontend/src/components/CellOverview.tsx
+++ b/frontend/src/components/CellOverview.tsx
@@ -67,6 +67,7 @@ type ImageState = {
   hu_mask?: string; // HU Mask画像
   map64?: string; // Map64画像
   map64_jet?: string; // Map64 Jet画像
+  map64_clip?: string; // Map64 clipped image
 };
 
 // 「どのモードにするか」を列挙型的に管理する
@@ -413,7 +414,7 @@ const CellImageGrid: React.FC = () => {
           const channelParam = map64Source === 'fluo2' ? 2 : 1;
           const imgTypeParam = map64Source === 'ph' ? 'ph' : 'fluo';
           setIsLoading(true);
-          const [rawRes, jetRes] = await Promise.all([
+          const [rawRes, jetRes, clipRes] = await Promise.all([
             axios.get(
               `${url_prefix}/cells/${cellId}/${db_name}/map64?degree=${fitDegree}&channel=${channelParam}&img_type=${imgTypeParam}`,
               { responseType: "blob" }
@@ -422,12 +423,17 @@ const CellImageGrid: React.FC = () => {
               `${url_prefix}/cells/${cellId}/${db_name}/map64_jet?degree=${fitDegree}&channel=${channelParam}&img_type=${imgTypeParam}`,
               { responseType: "blob" }
             ),
+            axios.get(
+              `${url_prefix}/cells/${cellId}/${db_name}/map64_clip?degree=${fitDegree}&channel=${channelParam}&img_type=${imgTypeParam}`,
+              { responseType: "blob" }
+            ),
           ]);
           const rawUrl = URL.createObjectURL(rawRes.data);
           const jetUrl = URL.createObjectURL(jetRes.data);
+          const clipUrl = URL.createObjectURL(clipRes.data);
           setImages((prev) => ({
             ...prev,
-            [cellId]: { ...prev[cellId], map64: rawUrl, map64_jet: jetUrl },
+            [cellId]: { ...prev[cellId], map64: rawUrl, map64_jet: jetUrl, map64_clip: clipUrl },
           }));
           setIsLoading(false);
           break;
@@ -1347,6 +1353,13 @@ const CellImageGrid: React.FC = () => {
                     alt={`Cell ${cellIds[currentIndex]} Map64`}
                     style={{ width: "100%" }}
                   />
+                  {images[cellIds[currentIndex]]?.map64_clip && (
+                    <img
+                      src={images[cellIds[currentIndex]]?.map64_clip}
+                      alt={`Cell ${cellIds[currentIndex]} Map64 Clip`}
+                      style={{ width: "100%" }}
+                    />
+                  )}
                   {images[cellIds[currentIndex]]?.map64_jet && (
                     <img
                       src={images[cellIds[currentIndex]]?.map64_jet}


### PR DESCRIPTION
## Summary
- add `get_map64_clip` API in backend for µ±3σ clipping and Gaussian blur subtraction
- expose new route `/map64_clip`
- fetch and show the clipped map alongside existing Map64 images in CellOverview

## Testing
- `./run_tests.sh` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6862a479633c832d8a54baba22b40f08