### PR TITLE
Add heatmap timecourse row for Timecourse All

### DIFF
--- a/backend/app/TimeLapseEngine/router.py
+++ b/backend/app/TimeLapseEngine/router.py
@@ -398,11 +398,10 @@ async def get_cell_timecourse_for_all_channels(
     draw_contour: bool = True,
 ):
     """
-    【新規APIエンドポイント】
-    "ph", "ph_replot", "fluo1", "fluo1_replot", "fluo2", "fluo2_replot"
-    の6パターン全てのタイムコース画像を縦方向に並べ、1枚のPNGで返す。
+    "ph", "fluo1", "fluo2" の3チャネルに加えて
+    ヒートマップのタイムコースを4行目に追加したPNGを返す。
 
-    404等が出たモードはスキップされるため、出力が6段未満になる可能性があります。
+    いずれかのチャネルで404が返された場合、その行はスキップされます。
     """
 
     crud = TimelapseDatabaseCrud(dbname=db_name)


### PR DESCRIPTION
## Summary
- add `get_cell_heatmap_timecourse_as_single_image` to build heatmap time courses
- include heatmap row in `get_all_channels_timecourse_as_single_image`
- update router doc for new behaviour
- remove heatmap GIF from frontend and show only 3 GIFs
- fetch contour area with AbortController to avoid race

## Testing
- `bash backend/app/run_tests.sh` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6864e227dc24832da2ec6f8e7bb2499b