### PR TITLE
Add MiniFileManager with backend support

### DIFF
--- a/backend/app/FileManager/router.py
+++ b/backend/app/FileManager/router.py
@@ -1,0 +1,42 @@
+import os
+import aiofiles
+from fastapi import APIRouter, UploadFile, HTTPException
+from fastapi.responses import FileResponse, JSONResponse
+
+UPLOAD_DIR = "uploaded_files"
+os.makedirs(UPLOAD_DIR, exist_ok=True)
+
+router_file_manager = APIRouter(tags=["file_manager"])
+
+@router_file_manager.get("/files")
+async def list_files():
+    try:
+        return [f for f in os.listdir(UPLOAD_DIR) if os.path.isfile(os.path.join(UPLOAD_DIR, f))]
+    except FileNotFoundError:
+        return []
+
+@router_file_manager.post("/upload")
+async def upload_file(file: UploadFile):
+    file_path = os.path.join(UPLOAD_DIR, file.filename)
+    try:
+        async with aiofiles.open(file_path, "wb") as out_file:
+            while chunk := await file.read(1024 * 1024):
+                await out_file.write(chunk)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+    return JSONResponse(content={"filename": file.filename})
+
+@router_file_manager.get("/download/{file_name}")
+async def download_file(file_name: str):
+    file_path = os.path.join(UPLOAD_DIR, file_name)
+    if not os.path.exists(file_path):
+        raise HTTPException(status_code=404, detail="File not found")
+    return FileResponse(file_path, filename=file_name)
+
+@router_file_manager.delete("/delete/{file_name}")
+async def delete_file(file_name: str):
+    file_path = os.path.join(UPLOAD_DIR, file_name)
+    if not os.path.exists(file_path):
+        raise HTTPException(status_code=404, detail="File not found")
+    os.remove(file_path)
+    return JSONResponse(content={"detail": "File deleted"})

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -16,6 +16,7 @@ from GraphEngine.router import router_graphengine
 from CDT.router import router_cdt
 from TimeLapseEngine.router import router_tl_engine
 from results.router import router_results
+from FileManager.router import router_file_manager
 from Auth.router import router_auth
 from Admin.router import router_admin
 from OAuth2.router import router_oauth2
@@ -148,6 +149,7 @@ app.include_router(router_dropbox, prefix=api_prefix)
 app.include_router(router_graphengine, prefix=api_prefix)
 app.include_router(router_cdt, prefix=api_prefix)
 app.include_router(router_results, prefix=api_prefix)
+app.include_router(router_file_manager, prefix=api_prefix)
 app.include_router(router_autolabel, prefix=api_prefix)
 app.include_router(router_oauth2, prefix=api_prefix)
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,6 +27,7 @@
     "react-plotly.js": "^2.6.0",
     "react-router-dom": "^6.24.1",
     "react-scripts": "5.0.1",
+    "lucide-react": "^0.263.0",
     "typescript": "^4.9.5",
     "web-vitals": "^2.1.4"
   },

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -19,6 +19,7 @@ import Login from "./components/Login";
 import UserInfo from "./components/Userinfo";
 import LabelSorter from "./components/LabelSorter";
 import CDT from "./components/CDT";
+import MiniFileManager from "./components/MiniFileManager";
 // ↑ 必要なコンポーネントをインポート
 
 /* --------------------------------
@@ -183,13 +184,21 @@ function App() {
               }
             />
             <Route
-            path="/tlengine/databases/"
-            element={
-              <Box component="main" sx={{ p: 1 }}>
-                <TimelapseViewer />
-              </Box>
-            }
-          />
+              path="/tlengine/databases/"
+              element={
+                <Box component="main" sx={{ p: 1 }}>
+                  <TimelapseViewer />
+                </Box>
+              }
+            />
+            <Route
+              path="/files"
+              element={
+                <Box component="main" sx={{ p: 1 }}>
+                  <MiniFileManager />
+                </Box>
+              }
+            />
             <Route
               path="/login"
               element={

--- a/frontend/src/components/MiniFileManager.tsx
+++ b/frontend/src/components/MiniFileManager.tsx
@@ -1,0 +1,851 @@
+import { useEffect, useState, type DragEvent } from 'react';
+import {
+  Upload,
+  Download,
+  Trash2,
+  FileText,
+  Image,
+  Video,
+  Music,
+  Archive,
+  File,
+  Grid3X3,
+  List,
+  Search,
+  Plus,
+  Folder,
+  HardDrive,
+  FileSpreadsheet,
+  Presentation,
+  FileCode,
+  Settings
+} from 'lucide-react';
+import { settings } from '../settings';
+
+const API_URL = settings.url_prefix;
+
+async function listFiles(): Promise<string[]> {
+  const res = await fetch(`${API_URL}/files`);
+  if (!res.ok) throw new Error('Failed to fetch files');
+  return await res.json();
+}
+
+async function uploadFile(file: File): Promise<void> {
+  const formData = new FormData();
+  formData.append('file', file);
+  const res = await fetch(`${API_URL}/upload`, {
+    method: 'POST',
+    body: formData,
+  });
+  if (!res.ok) throw new Error('Upload failed');
+}
+
+function downloadFile(filename: string) {
+  window.open(`${API_URL}/download/${encodeURIComponent(filename)}`);
+}
+
+async function deleteFile(filename: string): Promise<void> {
+  const res = await fetch(`${API_URL}/delete/${encodeURIComponent(filename)}`, {
+    method: 'DELETE',
+  });
+  if (!res.ok) throw new Error('Delete failed');
+}
+
+interface FileInfo {
+  name: string;
+  size?: string;
+  modified?: string;
+  type?: string;
+}
+
+function useResponsive() {
+  const [windowSize, setWindowSize] = useState({
+    width: typeof window !== 'undefined' ? window.innerWidth : 1200,
+    height: typeof window !== 'undefined' ? window.innerHeight : 800,
+  });
+
+  useEffect(() => {
+    function handleResize() {
+      setWindowSize({ width: window.innerWidth, height: window.innerHeight });
+    }
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  const isMobile = windowSize.width < 768;
+  const isTablet = windowSize.width < 1024 && windowSize.width >= 768;
+  return { windowSize, isMobile, isTablet };
+}
+
+function MiniFileManager() {
+  const [files, setFiles] = useState<FileInfo[]>([]);
+  const [selected, setSelected] = useState<File | null>(null);
+  const [viewMode, setViewMode] = useState<'grid' | 'list'>('grid');
+  const [searchTerm, setSearchTerm] = useState('');
+  const [isDragging, setIsDragging] = useState(false);
+  const [uploading, setUploading] = useState(false);
+  const [showMobileSearch, setShowMobileSearch] = useState(false);
+  const { isMobile, isTablet } = useResponsive();
+
+  const refresh = async () => {
+    try {
+      const names = await listFiles();
+      const fileInfos = names.map((name) => ({
+        name,
+        type: name.split('.').pop(),
+        size: '-- KB',
+        modified: new Date().toLocaleDateString('ja-JP'),
+      }));
+      setFiles(fileInfos);
+    } catch (error) {
+      console.error('Failed to fetch files:', error);
+    }
+  };
+
+  useEffect(() => {
+    refresh();
+  }, []);
+
+  useEffect(() => {
+    if (isMobile && viewMode === 'grid') {
+      setViewMode('list');
+    }
+  }, [isMobile, viewMode]);
+
+  const handleUpload = async () => {
+    if (selected) {
+      setUploading(true);
+      try {
+        await uploadFile(selected);
+        setSelected(null);
+        await refresh();
+      } catch (error) {
+        console.error('Upload failed:', error);
+      } finally {
+        setUploading(false);
+      }
+    }
+  };
+
+  const handleDelete = async (name: string) => {
+    try {
+      await deleteFile(name);
+      await refresh();
+    } catch (error) {
+      console.error('Delete failed:', error);
+    }
+  };
+
+  const handleDrop = (e: DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    setIsDragging(false);
+    const droppedFiles = Array.from(e.dataTransfer.files);
+    if (droppedFiles.length > 0) {
+      setSelected(droppedFiles[0]);
+    }
+  };
+
+  const handleDragOver = (e: DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    setIsDragging(true);
+  };
+
+  const handleDragLeave = (e: DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    setIsDragging(false);
+  };
+
+  const getFileIcon = (type: string) => {
+    const iconSize = isMobile ? '20px' : '24px';
+    const iconStyle = { width: iconSize, height: iconSize };
+    switch (type?.toLowerCase()) {
+      case 'pdf':
+        return <FileText style={{ ...iconStyle, color: '#dc2626' }} />;
+      case 'doc':
+      case 'docx':
+        return <FileText style={{ ...iconStyle, color: '#2563eb' }} />;
+      case 'txt':
+      case 'rtf':
+        return <FileText style={{ ...iconStyle, color: '#6b7280' }} />;
+      case 'xls':
+      case 'xlsx':
+      case 'csv':
+        return <FileSpreadsheet style={{ ...iconStyle, color: '#059669' }} />;
+      case 'ppt':
+      case 'pptx':
+        return <Presentation style={{ ...iconStyle, color: '#dc2626' }} />;
+      case 'jpg':
+      case 'jpeg':
+      case 'png':
+      case 'gif':
+      case 'svg':
+      case 'webp':
+      case 'bmp':
+      case 'tiff':
+        return <Image style={{ ...iconStyle, color: '#0061ff' }} />;
+      case 'mp4':
+      case 'avi':
+      case 'mov':
+      case 'mkv':
+      case 'wmv':
+      case 'flv':
+      case 'webm':
+        return <Video style={{ ...iconStyle, color: '#7c3aed' }} />;
+      case 'mp3':
+      case 'wav':
+      case 'flac':
+      case 'aac':
+      case 'ogg':
+      case 'm4a':
+        return <Music style={{ ...iconStyle, color: '#059669' }} />;
+      case 'zip':
+      case 'rar':
+      case '7z':
+      case 'tar':
+      case 'gz':
+      case 'bz2':
+        return <Archive style={{ ...iconStyle, color: '#d97706' }} />;
+      case 'js':
+      case 'ts':
+      case 'jsx':
+      case 'tsx':
+      case 'html':
+      case 'css':
+      case 'py':
+      case 'java':
+      case 'cpp':
+      case 'c':
+      case 'php':
+      case 'rb':
+      case 'go':
+      case 'rs':
+      case 'swift':
+      case 'kt':
+        return <FileCode style={{ ...iconStyle, color: '#f59e0b' }} />;
+      case 'json':
+      case 'xml':
+      case 'yaml':
+      case 'yml':
+      case 'toml':
+      case 'ini':
+      case 'cfg':
+        return <Settings style={{ ...iconStyle, color: '#8b5cf6' }} />;
+      default:
+        return <File style={{ ...iconStyle, color: '#6b7280' }} />;
+    }
+  };
+
+  const filteredFiles = files.filter((file) =>
+    file.name.toLowerCase().includes(searchTerm.toLowerCase())
+  );
+
+  const getGridColumns = () => {
+    if (isMobile) return 'repeat(auto-fill, minmax(150px, 1fr))';
+    if (isTablet) return 'repeat(auto-fill, minmax(180px, 1fr))';
+    return 'repeat(auto-fill, minmax(220px, 1fr))';
+  };
+
+  const DROPBOX_BLUE = '#0061ff';
+  const BORDER_COLOR = '#e5e5e5';
+  const TEXT_PRIMARY = '#1e1919';
+  const TEXT_SECONDARY = '#637282';
+  const BACKGROUND_GRAY = '#f7f9fa';
+
+  const headerStyle: React.CSSProperties = {
+    backgroundColor: '#ffffff',
+    borderBottom: `1px solid ${BORDER_COLOR}`,
+    boxShadow: '0 1px 2px rgba(0, 0, 0, 0.04)',
+  };
+
+  const containerStyle: React.CSSProperties = {
+    minHeight: '100vh',
+    backgroundColor: BACKGROUND_GRAY,
+    fontFamily:
+      '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", sans-serif',
+  };
+
+  const uploadAreaStyle: React.CSSProperties = {
+    border: `2px dashed ${isDragging ? DROPBOX_BLUE : '#c6c6c6'}`,
+    borderRadius: '8px',
+    padding: isMobile ? '24px 16px' : '40px 20px',
+    textAlign: 'center',
+    backgroundColor: isDragging ? '#f0f7ff' : '#ffffff',
+    transition: 'all 0.2s ease',
+    marginBottom: '24px',
+  };
+
+  const cardStyle: React.CSSProperties = {
+    backgroundColor: '#ffffff',
+    borderRadius: '8px',
+    border: `1px solid ${BORDER_COLOR}`,
+    transition: 'all 0.2s ease',
+    overflow: 'hidden',
+  };
+
+  const buttonStyle: React.CSSProperties = {
+    display: 'inline-flex',
+    alignItems: 'center',
+    padding: isMobile ? '12px 16px' : '10px 16px',
+    backgroundColor: DROPBOX_BLUE,
+    color: '#ffffff',
+    borderRadius: '6px',
+    border: 'none',
+    cursor: 'pointer',
+    fontSize: '14px',
+    fontWeight: '500',
+    transition: 'all 0.2s ease',
+  };
+
+  const iconButtonStyle: React.CSSProperties = {
+    padding: isMobile ? '8px' : '6px',
+    backgroundColor: 'transparent',
+    border: 'none',
+    borderRadius: '4px',
+    cursor: 'pointer',
+    color: TEXT_SECONDARY,
+    transition: 'all 0.2s ease',
+  };
+
+  const searchInputStyle: React.CSSProperties = {
+    paddingLeft: '36px',
+    paddingRight: '12px',
+    paddingTop: '8px',
+    paddingBottom: '8px',
+    border: `1px solid ${BORDER_COLOR}`,
+    borderRadius: '6px',
+    backgroundColor: '#ffffff',
+    color: TEXT_PRIMARY,
+    fontSize: '14px',
+    outline: 'none',
+    width: isMobile ? '100%' : '280px',
+  };
+
+  return (
+    <div style={containerStyle}>
+      <div style={headerStyle}>
+        <div style={{ width: '100%', padding: isMobile ? '0 16px' : '0 24px' }}>
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              height: isMobile ? '56px' : '60px',
+              flexWrap: isMobile ? 'wrap' : 'nowrap',
+            }}
+          >
+            <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+              <div
+                style={{
+                  width: isMobile ? '28px' : '32px',
+                  height: isMobile ? '28px' : '32px',
+                  backgroundColor: DROPBOX_BLUE,
+                  borderRadius: '4px',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                }}
+              >
+                <HardDrive
+                  style={{
+                    width: isMobile ? '16px' : '18px',
+                    height: isMobile ? '16px' : '18px',
+                    color: '#ffffff',
+                  }}
+                />
+              </div>
+              <h1
+                style={{
+                  fontSize: isMobile ? '18px' : '20px',
+                  fontWeight: '500',
+                  color: TEXT_PRIMARY,
+                  margin: 0,
+                }}
+              >
+                ファイル
+              </h1>
+            </div>
+            {!isMobile && (
+              <div style={{ display: 'flex', alignItems: 'center', gap: '16px' }}>
+                <div style={{ position: 'relative' }}>
+                  <Search
+                    style={{
+                      position: 'absolute',
+                      left: '12px',
+                      top: '50%',
+                      transform: 'translateY(-50%)',
+                      color: TEXT_SECONDARY,
+                      width: '16px',
+                      height: '16px',
+                    }}
+                  />
+                  <input
+                    type="text"
+                    placeholder="ファイルを検索"
+                    value={searchTerm}
+                    onChange={(e) => setSearchTerm(e.target.value)}
+                    style={searchInputStyle}
+                  />
+                </div>
+                <div
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    backgroundColor: BACKGROUND_GRAY,
+                    borderRadius: '6px',
+                    padding: '2px',
+                    border: `1px solid ${BORDER_COLOR}`,
+                  }}
+                >
+                  <button
+                    onClick={() => setViewMode('grid')}
+                    style={{
+                      padding: '6px',
+                      borderRadius: '4px',
+                      border: 'none',
+                      backgroundColor: viewMode === 'grid' ? '#ffffff' : 'transparent',
+                      color: TEXT_SECONDARY,
+                      cursor: 'pointer',
+                      boxShadow:
+                        viewMode === 'grid' ? '0 1px 2px rgba(0, 0, 0, 0.1)' : 'none',
+                    }}
+                  >
+                    <Grid3X3 style={{ width: '16px', height: '16px' }} />
+                  </button>
+                  <button
+                    onClick={() => setViewMode('list')}
+                    style={{
+                      padding: '6px',
+                      borderRadius: '4px',
+                      border: 'none',
+                      backgroundColor: viewMode === 'list' ? '#ffffff' : 'transparent',
+                      color: TEXT_SECONDARY,
+                      cursor: 'pointer',
+                      boxShadow:
+                        viewMode === 'list' ? '0 1px 2px rgba(0, 0, 0, 0.1)' : 'none',
+                    }}
+                  >
+                    <List style={{ width: '16px', height: '16px' }} />
+                  </button>
+                </div>
+              </div>
+            )}
+            {isMobile && (
+              <button
+                onClick={() => setShowMobileSearch(!showMobileSearch)}
+                style={{
+                  padding: '8px',
+                  backgroundColor: 'transparent',
+                  border: 'none',
+                  borderRadius: '4px',
+                  cursor: 'pointer',
+                  color: TEXT_SECONDARY,
+                }}
+              >
+                <Search style={{ width: '20px', height: '20px' }} />
+              </button>
+            )}
+          </div>
+          {isMobile && showMobileSearch && (
+            <div style={{ paddingBottom: '16px', position: 'relative' }}>
+              <Search
+                style={{
+                  position: 'absolute',
+                  left: '12px',
+                  top: '50%',
+                  transform: 'translateY(-50%)',
+                  color: TEXT_SECONDARY,
+                  width: '16px',
+                  height: '16px',
+                }}
+              />
+              <input
+                type="text"
+                placeholder="ファイルを検索"
+                value={searchTerm}
+                onChange={(e) => setSearchTerm(e.target.value)}
+                style={searchInputStyle}
+              />
+            </div>
+          )}
+        </div>
+      </div>
+      <div style={{ width: '100%', padding: isMobile ? '16px' : '24px' }}>
+        <div
+          style={uploadAreaStyle}
+          onDrop={handleDrop}
+          onDragOver={handleDragOver}
+          onDragLeave={handleDragLeave}
+        >
+          <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '16px' }}>
+            <Upload
+              style={{
+                width: isMobile ? '32px' : '40px',
+                height: isMobile ? '32px' : '40px',
+                color: TEXT_SECONDARY,
+              }}
+            />
+            <div>
+              <p
+                style={{
+                  fontSize: isMobile ? '14px' : '16px',
+                  fontWeight: '400',
+                  color: TEXT_PRIMARY,
+                  margin: '0 0 8px 0',
+                  textAlign: 'center',
+                }}
+              >
+                ファイルをドラッグ&ドロップするか
+              </p>
+              <div style={{ display: 'flex', justifyContent: 'center' }}>
+                <label style={{ cursor: 'pointer' }}>
+                  <span
+                    style={buttonStyle}
+                    onMouseEnter={(e) => {
+                      e.currentTarget.style.backgroundColor = '#0052cc';
+                    }}
+                    onMouseLeave={(e) => {
+                      e.currentTarget.style.backgroundColor = DROPBOX_BLUE;
+                    }}
+                  >
+                    <Plus style={{ width: '16px', height: '16px', marginRight: '6px' }} />
+                    ファイルを選択
+                  </span>
+                  <input
+                    type="file"
+                    style={{ display: 'none' }}
+                    onChange={(e) => setSelected(e.target.files ? e.target.files[0] : null)}
+                  />
+                </label>
+              </div>
+            </div>
+            {selected && (
+              <div
+                style={{
+                  backgroundColor: BACKGROUND_GRAY,
+                  borderRadius: '6px',
+                  padding: '16px',
+                  maxWidth: '400px',
+                  width: '100%',
+                  border: `1px solid ${BORDER_COLOR}`,
+                }}
+              >
+                <p style={{ fontSize: '14px', color: TEXT_SECONDARY, margin: '0 0 4px 0' }}>選択されたファイル:</p>
+                <p
+                  style={{
+                    fontWeight: '500',
+                    color: TEXT_PRIMARY,
+                    margin: '0 0 12px 0',
+                    wordBreak: 'break-all',
+                    fontSize: isMobile ? '13px' : '14px',
+                  }}
+                >
+                  {selected.name}
+                </p>
+                <button
+                  onClick={handleUpload}
+                  disabled={uploading}
+                  style={{
+                    ...buttonStyle,
+                    width: '100%',
+                    justifyContent: 'center',
+                    opacity: uploading ? 0.6 : 1,
+                    cursor: uploading ? 'not-allowed' : 'pointer',
+                  }}
+                  onMouseEnter={(e) => {
+                    if (!uploading) e.currentTarget.style.backgroundColor = '#0052cc';
+                  }}
+                  onMouseLeave={(e) => {
+                    if (!uploading) e.currentTarget.style.backgroundColor = DROPBOX_BLUE;
+                  }}
+                >
+                  {uploading ? 'アップロード中...' : 'アップロード'}
+                </button>
+              </div>
+            )}
+          </div>
+        </div>
+        {viewMode === 'grid' && !isMobile ? (
+          <div
+            style={{
+              display: 'grid',
+              gridTemplateColumns: getGridColumns(),
+              gap: isMobile ? '12px' : '16px',
+            }}
+          >
+            {filteredFiles.map((file, index) => (
+              <div
+                key={index}
+                style={{ ...cardStyle, cursor: 'pointer' }}
+                onMouseEnter={(e) => {
+                  e.currentTarget.style.boxShadow = '0 2px 8px rgba(0, 0, 0, 0.1)';
+                }}
+                onMouseLeave={(e) => {
+                  e.currentTarget.style.boxShadow = 'none';
+                }}
+              >
+                <div style={{ padding: isMobile ? '12px' : '16px' }}>
+                  <div style={{ display: 'flex', justifyContent: 'center', marginBottom: '12px' }}>
+                    {getFileIcon(file.type || '')}
+                  </div>
+                  <h3
+                    style={{
+                      fontWeight: '500',
+                      color: TEXT_PRIMARY,
+                      fontSize: isMobile ? '13px' : '14px',
+                      margin: '0 0 4px 0',
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                      whiteSpace: 'nowrap',
+                    }}
+                    title={file.name}
+                  >
+                    {file.name}
+                  </h3>
+                  <p style={{ fontSize: '12px', color: TEXT_SECONDARY, margin: '0' }}>{file.size}</p>
+                  <p style={{ fontSize: '12px', color: TEXT_SECONDARY, margin: '4px 0 0 0' }}>{file.modified}</p>
+                </div>
+                <div
+                  style={{
+                    borderTop: `1px solid ${BORDER_COLOR}`,
+                    backgroundColor: BACKGROUND_GRAY,
+                    padding: isMobile ? '6px 12px' : '8px 16px',
+                    display: 'flex',
+                    justifyContent: 'flex-end',
+                    gap: '4px',
+                  }}
+                >
+                  <button
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      downloadFile(file.name);
+                    }}
+                    style={iconButtonStyle}
+                    title="ダウンロード"
+                    onMouseEnter={(e) => {
+                      e.currentTarget.style.color = DROPBOX_BLUE;
+                      e.currentTarget.style.backgroundColor = '#f0f7ff';
+                    }}
+                    onMouseLeave={(e) => {
+                      e.currentTarget.style.color = TEXT_SECONDARY;
+                      e.currentTarget.style.backgroundColor = 'transparent';
+                    }}
+                  >
+                    <Download style={{ width: '16px', height: '16px' }} />
+                  </button>
+                  <button
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      handleDelete(file.name);
+                    }}
+                    style={iconButtonStyle}
+                    title="削除"
+                    onMouseEnter={(e) => {
+                      e.currentTarget.style.color = '#dc2626';
+                      e.currentTarget.style.backgroundColor = '#fef2f2';
+                    }}
+                    onMouseLeave={(e) => {
+                      e.currentTarget.style.color = TEXT_SECONDARY;
+                      e.currentTarget.style.backgroundColor = 'transparent';
+                    }}
+                  >
+                    <Trash2 style={{ width: '16px', height: '16px' }} />
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div style={cardStyle}>
+            {!isMobile && (
+              <div
+                style={{
+                  padding: '12px 20px',
+                  borderBottom: `1px solid ${BORDER_COLOR}`,
+                  backgroundColor: BACKGROUND_GRAY,
+                }}
+              >
+                <div
+                  style={{
+                    display: 'grid',
+                    gridTemplateColumns: isTablet ? '2fr 1fr 80px' : '2fr 1fr 1fr 100px',
+                    gap: '16px',
+                    fontSize: '12px',
+                    fontWeight: '600',
+                    color: TEXT_SECONDARY,
+                    textTransform: 'uppercase',
+                    letterSpacing: '0.05em',
+                  }}
+                >
+                  <div>名前</div>
+                  <div>サイズ</div>
+                  {!isTablet && <div>更新日時</div>}
+                  <div></div>
+                </div>
+              </div>
+            )}
+            <div>
+              {filteredFiles.map((file, index) => (
+                <div
+                  key={index}
+                  style={{
+                    padding: isMobile ? '16px' : '12px 20px',
+                    borderBottom:
+                      index < filteredFiles.length - 1 ? `1px solid ${BORDER_COLOR}` : 'none',
+                    transition: 'background-color 0.2s ease',
+                  }}
+                  onMouseEnter={(e) => {
+                    e.currentTarget.style.backgroundColor = BACKGROUND_GRAY;
+                  }}
+                  onMouseLeave={(e) => {
+                    e.currentTarget.style.backgroundColor = 'transparent';
+                  }}
+                >
+                  {isMobile ? (
+                    <div style={{ display: 'flex', alignItems: 'flex-start', gap: '12px' }}>
+                      <div style={{ flexShrink: 0, marginTop: '2px' }}>{getFileIcon(file.type || '')}</div>
+                      <div style={{ flex: 1, minWidth: 0 }}>
+                        <div
+                          style={{
+                            fontWeight: '500',
+                            color: TEXT_PRIMARY,
+                            fontSize: '14px',
+                            marginBottom: '4px',
+                            wordBreak: 'break-all',
+                          }}
+                        >
+                          {file.name}
+                        </div>
+                        <div style={{ fontSize: '13px', color: TEXT_SECONDARY, marginBottom: '8px' }}>
+                          {file.size} • {file.modified}
+                        </div>
+                      </div>
+                      <div style={{ display: 'flex', gap: '4px', flexShrink: 0 }}>
+                        <button
+                          onClick={() => downloadFile(file.name)}
+                          style={iconButtonStyle}
+                          title="ダウンロード"
+                          onMouseEnter={(e) => {
+                            e.currentTarget.style.color = DROPBOX_BLUE;
+                            e.currentTarget.style.backgroundColor = '#f0f7ff';
+                          }}
+                          onMouseLeave={(e) => {
+                            e.currentTarget.style.color = TEXT_SECONDARY;
+                            e.currentTarget.style.backgroundColor = 'transparent';
+                          }}
+                        >
+                          <Download style={{ width: '16px', height: '16px' }} />
+                        </button>
+                        <button
+                          onClick={() => handleDelete(file.name)}
+                          style={iconButtonStyle}
+                          title="削除"
+                          onMouseEnter={(e) => {
+                            e.currentTarget.style.color = '#dc2626';
+                            e.currentTarget.style.backgroundColor = '#fef2f2';
+                          }}
+                          onMouseLeave={(e) => {
+                            e.currentTarget.style.color = TEXT_SECONDARY;
+                            e.currentTarget.style.backgroundColor = 'transparent';
+                          }}
+                        >
+                          <Trash2 style={{ width: '16px', height: '16px' }} />
+                        </button>
+                      </div>
+                    </div>
+                  ) : (
+                    <div
+                      style={{
+                        display: 'grid',
+                        gridTemplateColumns: isTablet ? '2fr 1fr 80px' : '2fr 1fr 1fr 100px',
+                        gap: '16px',
+                        alignItems: 'center',
+                      }}
+                    >
+                      <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
+                        {getFileIcon(file.type || '')}
+                        <span
+                          style={{
+                            fontWeight: '400',
+                            color: TEXT_PRIMARY,
+                            fontSize: '14px',
+                            overflow: 'hidden',
+                            textOverflow: 'ellipsis',
+                            whiteSpace: 'nowrap',
+                          }}
+                        >
+                          {file.name}
+                        </span>
+                      </div>
+                      <div style={{ fontSize: '14px', color: TEXT_SECONDARY }}>{file.size}</div>
+                      {!isTablet && <div style={{ fontSize: '14px', color: TEXT_SECONDARY }}>{file.modified}</div>}
+                      <div style={{ display: 'flex', gap: '4px', justifyContent: 'flex-end' }}>
+                        <button
+                          onClick={() => downloadFile(file.name)}
+                          style={iconButtonStyle}
+                          title="ダウンロード"
+                          onMouseEnter={(e) => {
+                            e.currentTarget.style.color = DROPBOX_BLUE;
+                            e.currentTarget.style.backgroundColor = '#f0f7ff';
+                          }}
+                          onMouseLeave={(e) => {
+                            e.currentTarget.style.color = TEXT_SECONDARY;
+                            e.currentTarget.style.backgroundColor = 'transparent';
+                          }}
+                        >
+                          <Download style={{ width: '16px', height: '16px' }} />
+                        </button>
+                        <button
+                          onClick={() => handleDelete(file.name)}
+                          style={iconButtonStyle}
+                          title="削除"
+                          onMouseEnter={(e) => {
+                            e.currentTarget.style.color = '#dc2626';
+                            e.currentTarget.style.backgroundColor = '#fef2f2';
+                          }}
+                          onMouseLeave={(e) => {
+                            e.currentTarget.style.color = TEXT_SECONDARY;
+                            e.currentTarget.style.backgroundColor = 'transparent';
+                          }}
+                        >
+                          <Trash2 style={{ width: '16px', height: '16px' }} />
+                        </button>
+                      </div>
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+        {filteredFiles.length === 0 && (
+          <div
+            style={{
+              textAlign: 'center',
+              padding: isMobile ? '40px 20px' : '60px 20px',
+              ...cardStyle,
+            }}
+          >
+            <Folder
+              style={{
+                width: isMobile ? '40px' : '48px',
+                height: isMobile ? '40px' : '48px',
+                color: TEXT_SECONDARY,
+                margin: '0 auto 16px',
+              }}
+            />
+            <p style={{ color: TEXT_SECONDARY, margin: 0, fontSize: isMobile ? '14px' : '16px' }}>
+              {searchTerm ? '検索条件に一致するファイルが見つかりません' : 'ファイルがありません'}
+            </p>
+            {!searchTerm && (
+              <p style={{ color: TEXT_SECONDARY, margin: '8px 0 0 0', fontSize: isMobile ? '13px' : '14px' }}>
+                上のエリアにファイルをドラッグ&ドロップしてアップロードできます
+              </p>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default MiniFileManager;


### PR DESCRIPTION
## Summary
- add new MiniFileManager React component
- integrate MiniFileManager route in the frontend router
- add lucide-react dependency
- create backend file manager API with list/upload/download/delete
- expose new API router in FastAPI app

## Testing
- `bash backend/app/run_tests.sh` *(fails: ModuleNotFoundError: No module named 'httpx')*
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d2c784990832dbdc2c613a565e98f