### PR TITLE
Fix component imports

### DIFF
--- a/frontend/src/components/CellMorphoTable.tsx
+++ b/frontend/src/components/CellMorphoTable.tsx
@@ -1,5 +1,14 @@
 import React, { useEffect, useState } from 'react';
-import { Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Paper, Box } from '@material-ui/core';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Paper,
+  Box,
+} from "@mui/material";
 import { settings } from '../settings';
 
 interface CellMorphologyTableProps {

--- a/frontend/src/components/MiniFileManager.tsx
+++ b/frontend/src/components/MiniFileManager.tsx
@@ -9,7 +9,7 @@ import {
   Music,
   Archive,
   File,
-  Grid3X3,
+  Grid3x3,
   List,
   Search,
   Plus,
@@ -409,7 +409,7 @@ function MiniFileManager() {
                         viewMode === 'grid' ? '0 1px 2px rgba(0, 0, 0, 0.1)' : 'none',
                     }}
                   >
-                    <Grid3X3 style={{ width: '16px', height: '16px' }} />
+                    <Grid3x3 style={{ width: '16px', height: '16px' }} />
                   </button>
                   <button
                     onClick={() => setViewMode('list')}


### PR DESCRIPTION
## Summary
- fix Material UI imports in `CellMorphoTable`
- correct Grid3x3 icon import in `MiniFileManager`

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d7435d828832db9ad1e5867837341