### PR TITLE
Fix timelapse label update

### DIFF
--- a/backend/app/TimeLapseEngine/router.py
+++ b/backend/app/TimeLapseEngine/router.py
@@ -181,6 +181,7 @@ async def read_cell_by_cell_id(db_name: str, cell_id: str):
             content={
                 "id": cell.id,
                 "cell_id": cell.cell_id,
+                "base_cell_id": cell.base_cell_id,
                 "field": cell.field,
                 "time": cell.time,
                 "cell": cell.cell,
@@ -215,6 +216,7 @@ async def read_cells_by_cell_number(db_name: str, field: str, cell_number: int):
             {
                 "id": c.id,
                 "cell_id": c.cell_id,
+                "base_cell_id": c.base_cell_id,
                 "field": c.field,
                 "time": c.time,
                 "cell": c.cell,

--- a/frontend/src/components/TimelapseCellOverview.tsx
+++ b/frontend/src/components/TimelapseCellOverview.tsx
@@ -57,6 +57,7 @@ interface GetCellNumbersResponse {
 interface CellDataByFieldNumber {
   id: number;
   cell_id: string;
+  base_cell_id: string;
   field: string;
   time: number;
   cell: number;
@@ -71,6 +72,7 @@ interface GetCellsResponseByFieldNumber {
 interface CellDataById {
   id: number;
   cell_id: string;
+  base_cell_id: string;
   field: string;
   time: number;
   cell: number;
@@ -212,7 +214,7 @@ const TimelapseViewer: React.FC = () => {
         setCurrentCellData(null);
         return;
       }
-      const baseCellId = cells[0].cell_id; // 同じ cell_number の全フレームは同じ base_cell_id
+      const baseCellId = cells[0].base_cell_id; // 同じ cell_number の全フレームは同じ base_cell_id
       const detail = await fetchCellDataById(baseCellId);
       if (detail) {
         setCurrentCellData(detail);
@@ -229,7 +231,7 @@ const TimelapseViewer: React.FC = () => {
   const handleChangeManualLabel = async (value: string) => {
     if (!dbName || !currentCellData) return;
     try {
-      const baseCellId = currentCellData.cell_id;
+      const baseCellId = currentCellData.base_cell_id;
       await axios.patch(
         `${url_prefix}/tlengine/databases/${dbName}/cells/${baseCellId}/label?label=${value}`
       );
@@ -244,7 +246,7 @@ const TimelapseViewer: React.FC = () => {
   const handleChangeIsDead = async (checked: boolean) => {
     if (!dbName || !currentCellData) return;
     try {
-      const baseCellId = currentCellData.cell_id;
+      const baseCellId = currentCellData.base_cell_id;
       const isDeadValue = checked ? 1 : 0;
       await axios.patch(
         `${url_prefix}/tlengine/databases/${dbName}/cells/${baseCellId}/dead/${isDeadValue}`


### PR DESCRIPTION
## Summary
- include `base_cell_id` in timelapse API responses
- use `base_cell_id` in frontend when updating manual labels or dead status

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*
- `backend/app/run_tests.sh` *(fails: ModuleNotFoundError: httpx)*

------
https://chatgpt.com/codex/tasks/task_e_6875da959228832dbb7038e930916c27