### PR TITLE
Update timelapse label docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -814,6 +814,10 @@ All endpoints are prefixed with `/api`.
 | `GET` | `/tlengine/databases` | List timelapse cell databases. |
 | `GET` | `/tlengine/databases/{db}/fields` | List fields in a timelapse database. |
 | `GET` | `/tlengine/nd2_files/{file}/cells/{field}/gif` | Retrieve a GIF preview for a field. |
+| `GET` | `/tlengine/databases/{db}/fields/{field}/cell_numbers` | List cell numbers in a field. |
+| `PATCH` | `/tlengine/databases/{db}/cells/{base_cell_id}/label?label={label}` | Update `manual_label` for a base cell. |
+| `PATCH` | `/tlengine/databases/{db}/cells/{base_cell_id}/dead/{is_dead}` | Set dead status for a base cell. |
+| `GET` | `/tlengine/databases/{db}/cells/{field}/{cell_number}/replot` | Replot the entire time course as a GIF. |
 
 
 ## Additional Algorithms


### PR DESCRIPTION
## Summary
- document how to update `manual_label` and `is_dead` via timelapse APIs

## Testing
- `./run_tests.sh` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6875e28fb9b8832dbf1f734f457ef353