### PR TITLE
Fix Timelapse detail fetch

### DIFF
--- a/frontend/src/components/TimelapseCellOverview.tsx
+++ b/frontend/src/components/TimelapseCellOverview.tsx
@@ -216,8 +216,9 @@ const TimelapseViewer: React.FC = () => {
         setCurrentCellData(null);
         return;
       }
-      const baseCellId = cells[0].base_cell_id; // 同じ cell_number の全フレームは同じ base_cell_id
-      const detail = await fetchCellDataById(baseCellId);
+      // cell_id を使って詳細情報を取得する
+      const cellId = cells[0].cell_id;
+      const detail = await fetchCellDataById(cellId);
       if (detail) {
         setCurrentCellData(detail);
       } else {


### PR DESCRIPTION
## Summary
- fetch cell details using `cell_id` instead of `base_cell_id`

## Testing
- `bash backend/app/run_tests.sh` *(fails: ModuleNotFoundError: No module named 'httpx')*
- `npm test --silent` in `frontend` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875ed6823fc832d85344e319d987fbf