### PR TITLE
Filter databases by user if logged in

### DIFF
--- a/frontend/src/components/Databases.tsx
+++ b/frontend/src/components/Databases.tsx
@@ -94,7 +94,9 @@ const Databases: React.FC = () => {
    */
   const fetchDatabases = useCallback(async () => {
     try {
-      const response = await axios.get<ListDBResponse>(`${url_prefix}/databases`);
+      const token = localStorage.getItem("access_token");
+      const headers = token ? { Authorization: `Bearer ${token}` } : {};
+      const response = await axios.get<ListDBResponse>(`${url_prefix}/databases`, { headers });
       setDatabases(response.data.databases);
 
       // アップロード済みDBを抽出


### PR DESCRIPTION
## Summary
- send `Authorization` header when fetching database list so the backend can filter by logged-in user

## Testing
- `bash run_tests.sh` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6877b1042b10832db2e825464e4e9bf4