### PR TITLE
Fix validated databases visibility for logged-in users

### DIFF
--- a/frontend/src/components/Databases.tsx
+++ b/frontend/src/components/Databases.tsx
@@ -95,8 +95,14 @@ const Databases: React.FC = () => {
   const fetchDatabases = useCallback(async () => {
     try {
       const token = localStorage.getItem("access_token");
-      const headers = token ? { Authorization: `Bearer ${token}` } : {};
-      const response = await axios.get<ListDBResponse>(`${url_prefix}/databases`, { headers });
+      const headers =
+        token && displayMode !== "Validated"
+          ? { Authorization: `Bearer ${token}` }
+          : {};
+      const response = await axios.get<ListDBResponse>(
+        `${url_prefix}/databases`,
+        { headers }
+      );
       setDatabases(response.data.databases);
 
       // アップロード済みDBを抽出
@@ -154,7 +160,7 @@ const Databases: React.FC = () => {
     } catch (error) {
       console.error("Failed to fetch databases", error);
     }
-  }, []);
+  }, [displayMode]);
 
   /**
    * displayMode の変更に応じてデータを取得


### PR DESCRIPTION
## Summary
- adjust database fetch logic so validated mode fetches all databases even when logged in
- update callback dependencies

## Testing
- `./backend/app/run_tests.sh` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_687b78ba84a8832d9fad6b58b4c8661f