### PR TITLE
Add Image Playground card with edge detection

### DIFF
--- a/backend/app/image_playground/crud.py
+++ b/backend/app/image_playground/crud.py
@@ -1,0 +1,26 @@
+import asyncio
+from concurrent.futures import ThreadPoolExecutor
+import cv2
+import numpy as np
+
+class ImagePlaygroundCrud:
+    @staticmethod
+    def _apply_canny(data: bytes, threshold1: int, threshold2: int) -> bytes:
+        img_array = np.frombuffer(data, np.uint8)
+        img = cv2.imdecode(img_array, cv2.IMREAD_COLOR)
+        if img is None:
+            raise ValueError("Invalid image data")
+        gray = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
+        edges = cv2.Canny(gray, threshold1, threshold2)
+        success, buffer = cv2.imencode(".png", edges)
+        if not success:
+            raise ValueError("Failed to encode image")
+        return buffer.tobytes()
+
+    @classmethod
+    async def canny(cls, data: bytes, threshold1: int, threshold2: int) -> bytes:
+        loop = asyncio.get_event_loop()
+        with ThreadPoolExecutor() as executor:
+            return await loop.run_in_executor(
+                executor, cls._apply_canny, data, threshold1, threshold2
+            )

--- a/backend/app/image_playground/router.py
+++ b/backend/app/image_playground/router.py
@@ -1,0 +1,16 @@
+import io
+from fastapi import APIRouter, UploadFile, HTTPException
+from fastapi.responses import StreamingResponse
+from .crud import ImagePlaygroundCrud
+
+router_image_playground = APIRouter(prefix="/image_playground", tags=["image_playground"])
+
+
+@router_image_playground.post("/canny")
+async def canny_image(file: UploadFile, threshold1: int = 100, threshold2: int = 200):
+    try:
+        data = await file.read()
+        processed = await ImagePlaygroundCrud.canny(data, threshold1, threshold2)
+        return StreamingResponse(io.BytesIO(processed), media_type="image/png")
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -16,6 +16,7 @@ from CDT.router import router_cdt
 from TimeLapseEngine.router import router_tl_engine
 from results.router import router_results
 from FileManager.router import router_file_manager
+from image_playground.router import router_image_playground
 from Auth.router import router_auth
 from Admin.router import router_admin
 from OAuth2.router import router_oauth2
@@ -148,6 +149,7 @@ app.include_router(router_graphengine, prefix=api_prefix)
 app.include_router(router_cdt, prefix=api_prefix)
 app.include_router(router_results, prefix=api_prefix)
 app.include_router(router_file_manager, prefix=api_prefix)
+app.include_router(router_image_playground, prefix=api_prefix)
 app.include_router(router_autolabel, prefix=api_prefix)
 app.include_router(router_oauth2, prefix=api_prefix)
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -20,6 +20,7 @@ import UserInfo from "./components/Userinfo";
 import LabelSorter from "./components/LabelSorter";
 import CDT from "./components/CDT";
 import MiniFileManager from "./components/MiniFileManager";
+import ImagePlayground from "./components/ImagePlayground";
 // ↑ 必要なコンポーネントをインポート
 
 /* --------------------------------
@@ -196,6 +197,14 @@ function App() {
               element={
                 <Box component="main" sx={{ p: 1 }}>
                   <MiniFileManager />
+                </Box>
+              }
+            />
+            <Route
+              path="/image-playground"
+              element={
+                <Box component="main" sx={{ p: 1 }}>
+                  <ImagePlayground />
                 </Box>
               }
             />

--- a/frontend/src/components/ImagePlayground.tsx
+++ b/frontend/src/components/ImagePlayground.tsx
@@ -1,0 +1,88 @@
+import React, { useState } from "react";
+import {
+  Container,
+  TextField,
+  Button,
+  Stack,
+  Box,
+  Breadcrumbs,
+  Link,
+  Typography,
+} from "@mui/material";
+import { settings } from "../settings";
+
+const url_prefix = settings.url_prefix;
+
+const ImagePlayground: React.FC = () => {
+  const [file, setFile] = useState<File | null>(null);
+  const [threshold1, setThreshold1] = useState(100);
+  const [threshold2, setThreshold2] = useState(200);
+  const [imageSrc, setImageSrc] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.files?.length) {
+      setFile(e.target.files[0]);
+    }
+  };
+
+  const handleProcess = async () => {
+    if (!file) return;
+    const formData = new FormData();
+    formData.append("file", file);
+    setIsLoading(true);
+    try {
+      const res = await fetch(
+        `${url_prefix}/image_playground/canny?threshold1=${threshold1}&threshold2=${threshold2}`,
+        {
+          method: "POST",
+          body: formData,
+        }
+      );
+      if (!res.ok) throw new Error("Request failed");
+      const blob = await res.blob();
+      setImageSrc(URL.createObjectURL(blob));
+    } catch (err) {
+      console.error(err);
+      alert("Failed to process image");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <Container maxWidth="sm" sx={{ py: 4 }}>
+      <Breadcrumbs sx={{ mb: 3 }}>
+        <Link underline="hover" color="inherit" href="/">
+          Top
+        </Link>
+        <Typography color="text.primary">Image Playground</Typography>
+      </Breadcrumbs>
+      <Stack spacing={2}>
+        <input type="file" accept="image/*" onChange={handleFileChange} />
+        <TextField
+          label="Threshold1"
+          type="number"
+          value={threshold1}
+          onChange={(e) => setThreshold1(parseInt(e.target.value, 10))}
+          size="small"
+        />
+        <TextField
+          label="Threshold2"
+          type="number"
+          value={threshold2}
+          onChange={(e) => setThreshold2(parseInt(e.target.value, 10))}
+          size="small"
+        />
+        <Button variant="contained" onClick={handleProcess} disabled={isLoading}>
+          Apply Canny
+        </Button>
+        {imageSrc && (
+          <Box component="img" src={imageSrc} sx={{ width: "100%" }} />
+        )}
+      </Stack>
+    </Container>
+  );
+};
+
+export default ImagePlayground;

--- a/frontend/src/components/TopPage.tsx
+++ b/frontend/src/components/TopPage.tsx
@@ -18,6 +18,7 @@ import BarChartIcon from "@mui/icons-material/BarChart";
 import DisplaySettingsIcon from "@mui/icons-material/DisplaySettings";
 import Inventory2Icon from "@mui/icons-material/Inventory2";
 import AutoAwesomeMotionIcon from "@mui/icons-material/AutoAwesomeMotion";
+import ImageSearchIcon from "@mui/icons-material/ImageSearch";
 import { useNavigate } from "react-router-dom";
 import { settings } from "../settings";
 
@@ -277,6 +278,13 @@ const MenuGrid: React.FC<MenuGridProps> = ({ handleNavigate }) => {
         path: "/files",
         description: "Manage files on the local server.",
         external: true,
+      },
+      {
+        title: "Image Playground",
+        icon: <ImageSearchIcon sx={{ fontSize: 50 }} />,
+        path: "/image-playground",
+        description: "Try Canny edge detection on your images.",
+        external: false,
       },
     ],
     []


### PR DESCRIPTION
## Summary
- implement backend image_playground router and CRUD for Canny edge detection
- expose new router in backend `main.py`
- create frontend ImagePlayground component
- add Image Playground card to TopPage
- register new route in React app

## Testing
- `backend/app/run_tests.sh` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_687ce7dd3ab8832da45c3eb813bd2d74