### PR TITLE
Enable additional algorithms for ImagePlayground

### DIFF
--- a/backend/app/image_playground/crud.py
+++ b/backend/app/image_playground/crud.py
@@ -1,5 +1,6 @@
 import asyncio
 from concurrent.futures import ThreadPoolExecutor
+import io
 import cv2
 import numpy as np
 
@@ -23,4 +24,73 @@ class ImagePlaygroundCrud:
         with ThreadPoolExecutor() as executor:
             return await loop.run_in_executor(
                 executor, cls._apply_canny, data, threshold1, threshold2
+            )
+
+    @staticmethod
+    def _apply_sobel(data: bytes, ksize: int, dx: int, dy: int) -> bytes:
+        img_array = np.frombuffer(data, np.uint8)
+        img = cv2.imdecode(img_array, cv2.IMREAD_COLOR)
+        if img is None:
+            raise ValueError("Invalid image data")
+        gray = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
+        sobel = cv2.Sobel(gray, cv2.CV_64F, dx, dy, ksize=ksize)
+        sobel = cv2.convertScaleAbs(sobel)
+        success, buffer = cv2.imencode(".png", sobel)
+        if not success:
+            raise ValueError("Failed to encode image")
+        return buffer.tobytes()
+
+    @classmethod
+    async def sobel(cls, data: bytes, ksize: int, dx: int, dy: int) -> bytes:
+        loop = asyncio.get_event_loop()
+        with ThreadPoolExecutor() as executor:
+            return await loop.run_in_executor(
+                executor, cls._apply_sobel, data, ksize, dx, dy
+            )
+
+    @staticmethod
+    def _apply_gaussian(data: bytes, ksize: int, sigma_x: float, sigma_y: float) -> bytes:
+        img_array = np.frombuffer(data, np.uint8)
+        img = cv2.imdecode(img_array, cv2.IMREAD_COLOR)
+        if img is None:
+            raise ValueError("Invalid image data")
+        blurred = cv2.GaussianBlur(img, (ksize, ksize), sigma_x, sigma_y)
+        success, buffer = cv2.imencode(".png", blurred)
+        if not success:
+            raise ValueError("Failed to encode image")
+        return buffer.tobytes()
+
+    @classmethod
+    async def gaussian(cls, data: bytes, ksize: int, sigma_x: float, sigma_y: float) -> bytes:
+        loop = asyncio.get_event_loop()
+        with ThreadPoolExecutor() as executor:
+            return await loop.run_in_executor(
+                executor, cls._apply_gaussian, data, ksize, sigma_x, sigma_y
+            )
+
+    @staticmethod
+    def _apply_histogram(data: bytes, bins: int, normalize: bool) -> bytes:
+        import matplotlib.pyplot as plt
+        img_array = np.frombuffer(data, np.uint8)
+        img = cv2.imdecode(img_array, cv2.IMREAD_GRAYSCALE)
+        if img is None:
+            raise ValueError("Invalid image data")
+        hist = cv2.calcHist([img], [0], None, [bins], [0, 256])
+        if normalize:
+            hist = hist / hist.sum() if hist.sum() > 0 else hist
+        fig = plt.figure(figsize=(4, 3))
+        plt.plot(hist, color="gray")
+        plt.xlim([0, bins])
+        plt.tight_layout()
+        buf = io.BytesIO()
+        fig.savefig(buf, format="png")
+        plt.close(fig)
+        return buf.getvalue()
+
+    @classmethod
+    async def histogram(cls, data: bytes, bins: int, normalize: bool) -> bytes:
+        loop = asyncio.get_event_loop()
+        with ThreadPoolExecutor() as executor:
+            return await loop.run_in_executor(
+                executor, cls._apply_histogram, data, bins, normalize
             )

--- a/backend/app/image_playground/router.py
+++ b/backend/app/image_playground/router.py
@@ -14,3 +14,47 @@ async def canny_image(file: UploadFile, threshold1: int = 100, threshold2: int =
         return StreamingResponse(io.BytesIO(processed), media_type="image/png")
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
+
+
+@router_image_playground.post("/sobel")
+async def sobel_image(
+    file: UploadFile,
+    ksize: int = 3,
+    dx: int = 1,
+    dy: int = 1,
+):
+    try:
+        data = await file.read()
+        processed = await ImagePlaygroundCrud.sobel(data, ksize, dx, dy)
+        return StreamingResponse(io.BytesIO(processed), media_type="image/png")
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router_image_playground.post("/gaussian")
+async def gaussian_image(
+    file: UploadFile,
+    ksize: int = 5,
+    sigma_x: float = 1.0,
+    sigma_y: float = 1.0,
+):
+    try:
+        data = await file.read()
+        processed = await ImagePlaygroundCrud.gaussian(data, ksize, sigma_x, sigma_y)
+        return StreamingResponse(io.BytesIO(processed), media_type="image/png")
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router_image_playground.post("/histogram")
+async def histogram_image(
+    file: UploadFile,
+    bins: int = 256,
+    normalize: bool = False,
+):
+    try:
+        data = await file.read()
+        processed = await ImagePlaygroundCrud.histogram(data, bins, normalize)
+        return StreamingResponse(io.BytesIO(processed), media_type="image/png")
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))

--- a/frontend/src/components/ImagePlayground.tsx
+++ b/frontend/src/components/ImagePlayground.tsx
@@ -254,12 +254,13 @@ const ImagePlayground: React.FC = () => {
   };
 
   return (
-    <div style={{
-      minHeight: '100vh',
-      background: 'linear-gradient(135deg, #111827 0%, #000000 50%, #1f2937 100%)',
-      display: 'flex',
-      fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", sans-serif'
-    }}>
+    <div
+      style={{
+        display: 'flex',
+        width: '100%',
+        fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", sans-serif'
+      }}
+    >
       {/* Sidebar */}
       <div style={{
         width: sidebarOpen ? '320px' : '0',


### PR DESCRIPTION
## Summary
- tidy `ImagePlayground` layout so it embeds correctly
- extend backend `ImagePlayground` API to support Sobel, Gaussian blur and histogram

## Testing
- `./backend/app/run_tests.sh` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_687ceef4f9b8832d9b6cd1e3c320e3ec