### PR TITLE
Fix lint warnings and TypeScript errors

### DIFF
--- a/frontend/src/components/ImagePlayground.tsx
+++ b/frontend/src/components/ImagePlayground.tsx
@@ -1,8 +1,8 @@
 import React, { useState } from "react";
 import axios from "axios";
 import { settings } from "../settings";
-import { 
-  Upload, Settings, Image, ChevronRight, Activity, 
+import {
+  Upload, Settings, Image as ImageIcon, ChevronRight, Activity,
   Zap, Eye, BarChart3, Menu, X, Play, Download,
   Info, Clock, Cpu, LucideIcon
 } from "lucide-react";
@@ -764,7 +764,7 @@ const ImagePlayground: React.FC = () => {
                     padding: '32px',
                     color: '#6b7280'
                   }}>
-                    <Image size={48} style={{ 
+                    <ImageIcon size={48} style={{
                       margin: '0 auto 12px auto', 
                       opacity: 0.5,
                       display: 'block'

--- a/frontend/src/components/TopPage.tsx
+++ b/frontend/src/components/TopPage.tsx
@@ -154,6 +154,13 @@ const DemoDataset: React.FC<DemoDatasetProps> = ({ showDemo, cellId }) => {
     }
 
     let active = true;
+    let fetchedUrls: { ph: string | null; fluo: string | null; replot: string | null; plot3d: string | null } = {
+      ph: null,
+      fluo: null,
+      replot: null,
+      plot3d: null,
+    };
+
     const fetchDemoImages = async () => {
       try {
         const [res1, res2, res3, res4] = await Promise.all([
@@ -163,7 +170,7 @@ const DemoDataset: React.FC<DemoDatasetProps> = ({ showDemo, cellId }) => {
           fetch(`${settings.url_prefix}/cells/test_database.db/${cellId}/3d`),
         ]);
 
-        const newImageUrls = {
+        fetchedUrls = {
           ph: res1.ok ? URL.createObjectURL(await res1.blob()) : null,
           fluo: res2.ok ? URL.createObjectURL(await res2.blob()) : null,
           replot: res3.ok ? URL.createObjectURL(await res3.blob()) : null,
@@ -171,7 +178,7 @@ const DemoDataset: React.FC<DemoDatasetProps> = ({ showDemo, cellId }) => {
         };
 
         if (active) {
-          setImageUrls(newImageUrls);
+          setImageUrls(fetchedUrls);
         }
       } catch (error) {
         console.error("Error fetching demo images:", error);
@@ -182,7 +189,7 @@ const DemoDataset: React.FC<DemoDatasetProps> = ({ showDemo, cellId }) => {
 
     return () => {
       active = false;
-      Object.values(imageUrls).forEach((url) => {
+      Object.values(fetchedUrls).forEach((url) => {
         if (url) URL.revokeObjectURL(url);
       });
     };

--- a/frontend/src/components/Userinfo.tsx
+++ b/frontend/src/components/Userinfo.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useCallback } from "react";
 import {
   Box,
   Button,
@@ -41,7 +41,7 @@ const UserInfo: React.FC = () => {
 
   const navigate = useNavigate();
 
-  const fetchUserInfo = async () => {
+  const fetchUserInfo = useCallback(async () => {
     setLoading(true);
     setError("");
     const accessToken = localStorage.getItem("access_token");
@@ -72,11 +72,11 @@ const UserInfo: React.FC = () => {
     } finally {
       setLoading(false);
     }
-  };
+  }, [navigate]);
 
   useEffect(() => {
     fetchUserInfo();
-  }, [navigate]);
+  }, [fetchUserInfo]);
 
   const handleLogout = () => {
     localStorage.removeItem("access_token");


### PR DESCRIPTION
## Summary
- rename `Image` icon to avoid conflict with DOM class
- track fetched demo image URLs locally so `useEffect` does not warn
- memoize `fetchUserInfo` to satisfy React hook deps

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*
- `bash backend/app/run_tests.sh` *(fails: ModuleNotFoundError: No module named 'httpx')*


------
https://chatgpt.com/codex/tasks/task_e_687cf2b72dfc832d9f62906a1cfae63f