### PR TITLE
Add SD & CV metrics

### DIFF
--- a/backend/app/CellDBConsole/router.py
+++ b/backend/app/CellDBConsole/router.py
@@ -365,6 +365,32 @@ async def get_var_fluo_intensities(db_name: str, label: str, cell_id: str):
     return ret
 
 
+@router_cell.get("/{db_name}/{label}/{cell_id}/sd_fluo_intensities")
+async def get_sd_fluo_intensities(db_name: str, label: str, cell_id: str):
+    await AsyncChores().validate_database_name(db_name)
+    ret: StreamingResponse = await CellCrudBase(
+        db_name=db_name
+    ).get_all_sd_normalized_fluo_intensities(
+        label=label,
+        cell_id=cell_id,
+        y_label="SD Normalized Fluorescence Intensity",
+    )
+    return ret
+
+
+@router_cell.get("/{db_name}/{label}/{cell_id}/cv_fluo_intensities")
+async def get_cv_fluo_intensities(db_name: str, label: str, cell_id: str):
+    await AsyncChores().validate_database_name(db_name)
+    ret: StreamingResponse = await CellCrudBase(
+        db_name=db_name
+    ).get_all_cv_normalized_fluo_intensities(
+        label=label,
+        cell_id=cell_id,
+        y_label="CV Normalized Fluorescence Intensity",
+    )
+    return ret
+
+
 @router_cell.get("/{db_name}/{label}/{cell_id}/area_fraction")
 async def get_area_fraction(db_name: str, label: str, cell_id: str):
     await AsyncChores().validate_database_name(db_name)
@@ -406,6 +432,26 @@ async def get_var_fluo_intensities_csv(db_name: str, label: str):
     return await CellCrudBase(
         db_name=db_name
     ).get_all_variance_normalized_fluo_intensities_csv(label=label)
+
+
+@router_cell.get(
+    "/{db_name}/{label}/sd_fluo_intensities/csv", response_class=StreamingResponse
+)
+async def get_sd_fluo_intensities_csv(db_name: str, label: str):
+    await AsyncChores().validate_database_name(db_name)
+    return await CellCrudBase(
+        db_name=db_name
+    ).get_all_sd_normalized_fluo_intensities_csv(label=label)
+
+
+@router_cell.get(
+    "/{db_name}/{label}/cv_fluo_intensities/csv", response_class=StreamingResponse
+)
+async def get_cv_fluo_intensities_csv(db_name: str, label: str):
+    await AsyncChores().validate_database_name(db_name)
+    return await CellCrudBase(
+        db_name=db_name
+    ).get_all_cv_normalized_fluo_intensities_csv(label=label)
 
 
 @router_cell.get(

--- a/frontend/src/components/CVEngine.tsx
+++ b/frontend/src/components/CVEngine.tsx
@@ -1,0 +1,81 @@
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
+import { Box, CircularProgress, Button } from '@mui/material';
+import { settings } from '../settings';
+import DownloadIcon from '@mui/icons-material/Download';
+
+interface ImageFetcherProps {
+    dbName: string;
+    label: string;
+    cellId: string;
+}
+const url_prefix = settings.url_prefix;
+
+const CVEngine: React.FC<ImageFetcherProps> = ({ dbName, label, cellId }) => {
+    const [imageUrl, setImageUrl] = useState<string | null>(null);
+    const [loading, setLoading] = useState<boolean>(false);
+
+    useEffect(() => {
+        const fetchImageData = async () => {
+            setLoading(true);
+            try {
+                const response = await axios.get(`${url_prefix}/cells/${dbName}/${label}/${cellId}/cv_fluo_intensities`, { responseType: 'blob' });
+                const imageBlobUrl = URL.createObjectURL(response.data);
+                setImageUrl(imageBlobUrl);
+            } catch (error) {
+                console.error('Failed to fetch image data:', error);
+                setImageUrl(null);
+            } finally {
+                setLoading(false);
+            }
+        };
+
+        fetchImageData();
+    }, [dbName, label, cellId]);
+
+    const handleDownloadCsv = async () => {
+        try {
+            const response = await axios.get(`${url_prefix}/cells/${dbName}/${label}/cv_fluo_intensities/csv`, { responseType: 'blob' });
+            const url = window.URL.createObjectURL(new Blob([response.data]));
+            const link = document.createElement('a');
+            link.href = url;
+            link.setAttribute('download', `${dbName}_cv_fluo_intensities.csv`);
+            document.body.appendChild(link);
+            link.click();
+            link?.parentNode?.removeChild(link);
+        } catch (error) {
+            console.error('Failed to download CSV:', error);
+        }
+    };
+
+    if (loading) {
+        return <Box display="flex" justifyContent="center"><CircularProgress /></Box>;
+    }
+
+    if (!imageUrl) {
+        return <Box>No image available</Box>;
+    }
+
+    return (
+        <Box display="flex" flexDirection="column" alignItems="right">
+            <img src={imageUrl} alt="Cell" style={{ maxWidth: '100%', height: 'auto' }} />
+            <Button
+                variant="contained"
+                onClick={handleDownloadCsv}
+                sx={{
+                    color: 'black',
+                    backgroundColor: '#ffffff',
+                    '&:hover': {
+                        backgroundColor: '#e0e0e0',
+                    },
+                    marginTop: 1,
+                }}
+                startIcon={<DownloadIcon />}
+            >
+                Download CSV
+            </Button>
+        </Box>
+    );
+};
+
+export default CVEngine;

--- a/frontend/src/components/CellOverview.tsx
+++ b/frontend/src/components/CellOverview.tsx
@@ -27,6 +27,8 @@ import MeanEngine from "./MeanEngine";
 import HeatmapEngine from "./HeatmapEngine";
 import VarEngine from "./VarEngine";
 import AreaFractionEngine from "./AreaFractionEngine";
+import SDEngine from "./SDEngine";
+import CVEngine from "./CVEngine";
 
 import {
   Chart as ChartJS,
@@ -94,7 +96,9 @@ type EngineName =
   | "MeanEngine"
   | "HeatmapEngine"
   | "VarEngine"
-  | "AreaFractionEngine";
+  | "AreaFractionEngine"
+  | "SDEngine"
+  | "CVEngine";
 
 // MorphoEngineロゴマッピング
 const engineLogos: Record<EngineName, string> = {
@@ -105,6 +109,8 @@ const engineLogos: Record<EngineName, string> = {
   VarEngine: "/var_logo.png",
   AreaFractionEngine: "/logo_cross.png",
   HeatmapEngine: "/logo_heatmap.png",
+  SDEngine: "/var_logo.png",
+  CVEngine: "/var_logo.png",
 };
 
 //-----------------------------------
@@ -1522,6 +1528,26 @@ const CellImageGrid: React.FC = () => {
           {engineMode === "VarEngine" && (
             <Box mt={6}>
               <VarEngine
+                dbName={db_name}
+                label={selectedLabel}
+                cellId={cellIds[currentIndex]}
+              />
+            </Box>
+          )}
+
+          {engineMode === "SDEngine" && (
+            <Box mt={6}>
+              <SDEngine
+                dbName={db_name}
+                label={selectedLabel}
+                cellId={cellIds[currentIndex]}
+              />
+            </Box>
+          )}
+
+          {engineMode === "CVEngine" && (
+            <Box mt={6}>
+              <CVEngine
                 dbName={db_name}
                 label={selectedLabel}
                 cellId={cellIds[currentIndex]}

--- a/frontend/src/components/SDEngine.tsx
+++ b/frontend/src/components/SDEngine.tsx
@@ -1,0 +1,81 @@
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
+import { Box, CircularProgress, Button } from '@mui/material';
+import { settings } from '../settings';
+import DownloadIcon from '@mui/icons-material/Download';
+
+interface ImageFetcherProps {
+    dbName: string;
+    label: string;
+    cellId: string;
+}
+const url_prefix = settings.url_prefix;
+
+const SDEngine: React.FC<ImageFetcherProps> = ({ dbName, label, cellId }) => {
+    const [imageUrl, setImageUrl] = useState<string | null>(null);
+    const [loading, setLoading] = useState<boolean>(false);
+
+    useEffect(() => {
+        const fetchImageData = async () => {
+            setLoading(true);
+            try {
+                const response = await axios.get(`${url_prefix}/cells/${dbName}/${label}/${cellId}/sd_fluo_intensities`, { responseType: 'blob' });
+                const imageBlobUrl = URL.createObjectURL(response.data);
+                setImageUrl(imageBlobUrl);
+            } catch (error) {
+                console.error('Failed to fetch image data:', error);
+                setImageUrl(null);
+            } finally {
+                setLoading(false);
+            }
+        };
+
+        fetchImageData();
+    }, [dbName, label, cellId]);
+
+    const handleDownloadCsv = async () => {
+        try {
+            const response = await axios.get(`${url_prefix}/cells/${dbName}/${label}/sd_fluo_intensities/csv`, { responseType: 'blob' });
+            const url = window.URL.createObjectURL(new Blob([response.data]));
+            const link = document.createElement('a');
+            link.href = url;
+            link.setAttribute('download', `${dbName}_sd_fluo_intensities.csv`);
+            document.body.appendChild(link);
+            link.click();
+            link?.parentNode?.removeChild(link);
+        } catch (error) {
+            console.error('Failed to download CSV:', error);
+        }
+    };
+
+    if (loading) {
+        return <Box display="flex" justifyContent="center"><CircularProgress /></Box>;
+    }
+
+    if (!imageUrl) {
+        return <Box>No image available</Box>;
+    }
+
+    return (
+        <Box display="flex" flexDirection="column" alignItems="right">
+            <img src={imageUrl} alt="Cell" style={{ maxWidth: '100%', height: 'auto' }} />
+            <Button
+                variant="contained"
+                onClick={handleDownloadCsv}
+                sx={{
+                    color: 'black',
+                    backgroundColor: '#ffffff',
+                    '&:hover': {
+                        backgroundColor: '#e0e0e0',
+                    },
+                    marginTop: 1,
+                }}
+                startIcon={<DownloadIcon />}
+            >
+                Download CSV
+            </Button>
+        </Box>
+    );
+};
+
+export default SDEngine;


### PR DESCRIPTION
## Summary
- support SD/CV measurement for fluorescent intensities
- show SD/CV values on replot images
- implement SDEngine and CVEngine for CellOverview page

## Testing
- `backend/app/testing/test_all.sh` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_688326bdb9a0832dbc9f5d0976387e7a