### PR TITLE
Allow channel selection for CV/SD engines

### DIFF
--- a/backend/app/CellDBConsole/crud.py
+++ b/backend/app/CellDBConsole/crud.py
@@ -1759,22 +1759,40 @@ class CellCrudBase:
         return StreamingResponse(ret, media_type="image/png")
 
     async def get_all_sd_normalized_fluo_intensities(
-        self, cell_id: str, y_label: str, label: str | None = None
+        self,
+        cell_id: str,
+        y_label: str,
+        label: str | None = None,
+        img_type: Literal["ph", "fluo1", "fluo2"] = "fluo1",
     ) -> StreamingResponse:
         cell_ids = await self.read_cell_ids(label)
         cells = await asyncio.gather(
             *(self.read_cell(cell.cell_id) for cell in cell_ids)
         )
         target_cell = await self.read_cell(cell_id=cell_id)
+        if img_type == "ph":
+            target_img = target_cell.img_ph
+        elif img_type == "fluo2":
+            target_img = target_cell.img_fluo2
+        else:
+            target_img = target_cell.img_fluo1
+
         target_val = (
             await AsyncChores.calc_sd_normalized_fluo_intensity_inside_cell(
-                target_cell.img_fluo1, target_cell.contour
+                target_img, target_cell.contour
             )
         )
         sd_intensities = await asyncio.gather(
             *(
                 AsyncChores.calc_sd_normalized_fluo_intensity_inside_cell(
-                    cell.img_fluo1, cell.contour
+                    (
+                        cell.img_ph
+                        if img_type == "ph"
+                        else cell.img_fluo2
+                        if img_type == "fluo2"
+                        else cell.img_fluo1
+                    ),
+                    cell.contour,
                 )
                 for cell in cells
             )
@@ -1789,22 +1807,40 @@ class CellCrudBase:
         return StreamingResponse(ret, media_type="image/png")
 
     async def get_all_cv_normalized_fluo_intensities(
-        self, cell_id: str, y_label: str, label: str | None = None
+        self,
+        cell_id: str,
+        y_label: str,
+        label: str | None = None,
+        img_type: Literal["ph", "fluo1", "fluo2"] = "fluo1",
     ) -> StreamingResponse:
         cell_ids = await self.read_cell_ids(label)
         cells = await asyncio.gather(
             *(self.read_cell(cell.cell_id) for cell in cell_ids)
         )
         target_cell = await self.read_cell(cell_id=cell_id)
+        if img_type == "ph":
+            target_img = target_cell.img_ph
+        elif img_type == "fluo2":
+            target_img = target_cell.img_fluo2
+        else:
+            target_img = target_cell.img_fluo1
+
         target_val = (
             await AsyncChores.calc_cv_normalized_fluo_intensity_inside_cell(
-                target_cell.img_fluo1, target_cell.contour
+                target_img, target_cell.contour
             )
         )
         cv_intensities = await asyncio.gather(
             *(
                 AsyncChores.calc_cv_normalized_fluo_intensity_inside_cell(
-                    cell.img_fluo1, cell.contour
+                    (
+                        cell.img_ph
+                        if img_type == "ph"
+                        else cell.img_fluo2
+                        if img_type == "fluo2"
+                        else cell.img_fluo1
+                    ),
+                    cell.contour,
                 )
                 for cell in cells
             )
@@ -1950,7 +1986,9 @@ class CellCrudBase:
         return StreamingResponse(buf, media_type="text/csv")
 
     async def get_all_sd_normalized_fluo_intensities_csv(
-        self, label: str | None = None
+        self,
+        label: str | None = None,
+        img_type: Literal["ph", "fluo1", "fluo2"] = "fluo1",
     ) -> StreamingResponse:
         cell_ids = await self.read_cell_ids(label)
         cells = await asyncio.gather(
@@ -1959,7 +1997,14 @@ class CellCrudBase:
         sd_intensities = await asyncio.gather(
             *(
                 AsyncChores.calc_sd_normalized_fluo_intensity_inside_cell(
-                    cell.img_fluo1, cell.contour
+                    (
+                        cell.img_ph
+                        if img_type == "ph"
+                        else cell.img_fluo2
+                        if img_type == "fluo2"
+                        else cell.img_fluo1
+                    ),
+                    cell.contour,
                 )
                 for cell in cells
             )
@@ -1976,7 +2021,9 @@ class CellCrudBase:
         return StreamingResponse(buf, media_type="text/csv")
 
     async def get_all_cv_normalized_fluo_intensities_csv(
-        self, label: str | None = None
+        self,
+        label: str | None = None,
+        img_type: Literal["ph", "fluo1", "fluo2"] = "fluo1",
     ) -> StreamingResponse:
         cell_ids = await self.read_cell_ids(label)
         cells = await asyncio.gather(
@@ -1985,7 +2032,14 @@ class CellCrudBase:
         cv_intensities = await asyncio.gather(
             *(
                 AsyncChores.calc_cv_normalized_fluo_intensity_inside_cell(
-                    cell.img_fluo1, cell.contour
+                    (
+                        cell.img_ph
+                        if img_type == "ph"
+                        else cell.img_fluo2
+                        if img_type == "fluo2"
+                        else cell.img_fluo1
+                    ),
+                    cell.contour,
                 )
                 for cell in cells
             )

--- a/backend/app/CellDBConsole/router.py
+++ b/backend/app/CellDBConsole/router.py
@@ -366,7 +366,12 @@ async def get_var_fluo_intensities(db_name: str, label: str, cell_id: str):
 
 
 @router_cell.get("/{db_name}/{label}/{cell_id}/sd_fluo_intensities")
-async def get_sd_fluo_intensities(db_name: str, label: str, cell_id: str):
+async def get_sd_fluo_intensities(
+    db_name: str,
+    label: str,
+    cell_id: str,
+    img_type: Literal["ph", "fluo1", "fluo2"] = "fluo1",
+):
     await AsyncChores().validate_database_name(db_name)
     ret: StreamingResponse = await CellCrudBase(
         db_name=db_name
@@ -374,12 +379,18 @@ async def get_sd_fluo_intensities(db_name: str, label: str, cell_id: str):
         label=label,
         cell_id=cell_id,
         y_label="SD Normalized Fluorescence Intensity",
+        img_type=img_type,
     )
     return ret
 
 
 @router_cell.get("/{db_name}/{label}/{cell_id}/cv_fluo_intensities")
-async def get_cv_fluo_intensities(db_name: str, label: str, cell_id: str):
+async def get_cv_fluo_intensities(
+    db_name: str,
+    label: str,
+    cell_id: str,
+    img_type: Literal["ph", "fluo1", "fluo2"] = "fluo1",
+):
     await AsyncChores().validate_database_name(db_name)
     ret: StreamingResponse = await CellCrudBase(
         db_name=db_name
@@ -387,6 +398,7 @@ async def get_cv_fluo_intensities(db_name: str, label: str, cell_id: str):
         label=label,
         cell_id=cell_id,
         y_label="CV Normalized Fluorescence Intensity",
+        img_type=img_type,
     )
     return ret
 
@@ -437,21 +449,29 @@ async def get_var_fluo_intensities_csv(db_name: str, label: str):
 @router_cell.get(
     "/{db_name}/{label}/sd_fluo_intensities/csv", response_class=StreamingResponse
 )
-async def get_sd_fluo_intensities_csv(db_name: str, label: str):
+async def get_sd_fluo_intensities_csv(
+    db_name: str,
+    label: str,
+    img_type: Literal["ph", "fluo1", "fluo2"] = "fluo1",
+):
     await AsyncChores().validate_database_name(db_name)
     return await CellCrudBase(
         db_name=db_name
-    ).get_all_sd_normalized_fluo_intensities_csv(label=label)
+    ).get_all_sd_normalized_fluo_intensities_csv(label=label, img_type=img_type)
 
 
 @router_cell.get(
     "/{db_name}/{label}/cv_fluo_intensities/csv", response_class=StreamingResponse
 )
-async def get_cv_fluo_intensities_csv(db_name: str, label: str):
+async def get_cv_fluo_intensities_csv(
+    db_name: str,
+    label: str,
+    img_type: Literal["ph", "fluo1", "fluo2"] = "fluo1",
+):
     await AsyncChores().validate_database_name(db_name)
     return await CellCrudBase(
         db_name=db_name
-    ).get_all_cv_normalized_fluo_intensities_csv(label=label)
+    ).get_all_cv_normalized_fluo_intensities_csv(label=label, img_type=img_type)
 
 
 @router_cell.get(

--- a/frontend/src/components/CVEngine.tsx
+++ b/frontend/src/components/CVEngine.tsx
@@ -8,10 +8,11 @@ interface ImageFetcherProps {
     dbName: string;
     label: string;
     cellId: string;
+    imgType: 'ph' | 'fluo1' | 'fluo2';
 }
 const url_prefix = settings.url_prefix;
 
-const CVEngine: React.FC<ImageFetcherProps> = ({ dbName, label, cellId }) => {
+const CVEngine: React.FC<ImageFetcherProps> = ({ dbName, label, cellId, imgType }) => {
     const [imageUrl, setImageUrl] = useState<string | null>(null);
     const [loading, setLoading] = useState<boolean>(false);
 
@@ -19,7 +20,10 @@ const CVEngine: React.FC<ImageFetcherProps> = ({ dbName, label, cellId }) => {
         const fetchImageData = async () => {
             setLoading(true);
             try {
-                const response = await axios.get(`${url_prefix}/cells/${dbName}/${label}/${cellId}/cv_fluo_intensities`, { responseType: 'blob' });
+                const response = await axios.get(
+                    `${url_prefix}/cells/${dbName}/${label}/${cellId}/cv_fluo_intensities?img_type=${imgType}`,
+                    { responseType: 'blob' }
+                );
                 const imageBlobUrl = URL.createObjectURL(response.data);
                 setImageUrl(imageBlobUrl);
             } catch (error) {
@@ -35,7 +39,10 @@ const CVEngine: React.FC<ImageFetcherProps> = ({ dbName, label, cellId }) => {
 
     const handleDownloadCsv = async () => {
         try {
-            const response = await axios.get(`${url_prefix}/cells/${dbName}/${label}/cv_fluo_intensities/csv`, { responseType: 'blob' });
+            const response = await axios.get(
+                `${url_prefix}/cells/${dbName}/${label}/cv_fluo_intensities/csv?img_type=${imgType}`,
+                { responseType: 'blob' }
+            );
             const url = window.URL.createObjectURL(new Blob([response.data]));
             const link = document.createElement('a');
             link.href = url;

--- a/frontend/src/components/CellOverview.tsx
+++ b/frontend/src/components/CellOverview.tsx
@@ -176,6 +176,7 @@ const CellImageGrid: React.FC = () => {
   const [drawMode, setDrawMode] = useState<DrawModeType>(init_draw_mode);
   const [fitDegree, setFitDegree] = useState<number>(4);
   const [map256Source, setMap256Source] = useState<'ph' | 'fluo1' | 'fluo2'>('fluo1');
+  const [statSource, setStatSource] = useState<'ph' | 'fluo1' | 'fluo2'>('fluo1');
   const [engineMode, setEngineMode] = useState<EngineName>("None");
 
   // DetectMode 用の state
@@ -1476,6 +1477,26 @@ const CellImageGrid: React.FC = () => {
             </FormControl>
           </Box>
 
+          {(engineMode === "SDEngine" || engineMode === "CVEngine") && (
+            <Box sx={{ mb: 2 }}>
+              <FormControl fullWidth variant="outlined">
+                <InputLabel id="stat-source-label">Channel</InputLabel>
+                <Select
+                  labelId="stat-source-label"
+                  label="Channel"
+                  value={statSource}
+                  onChange={(e) =>
+                    setStatSource(e.target.value as "ph" | "fluo1" | "fluo2")
+                  }
+                >
+                  <MenuItem value="ph">ph</MenuItem>
+                  <MenuItem value="fluo1">fluo1</MenuItem>
+                  {hasFluo2 && <MenuItem value="fluo2">fluo2</MenuItem>}
+                </Select>
+              </FormControl>
+            </Box>
+          )}
+
           {engineMode === "None" && (
             <Box
               sx={{
@@ -1541,6 +1562,7 @@ const CellImageGrid: React.FC = () => {
                 dbName={db_name}
                 label={selectedLabel}
                 cellId={cellIds[currentIndex]}
+                imgType={statSource}
               />
             </Box>
           )}
@@ -1551,6 +1573,7 @@ const CellImageGrid: React.FC = () => {
                 dbName={db_name}
                 label={selectedLabel}
                 cellId={cellIds[currentIndex]}
+                imgType={statSource}
               />
             </Box>
           )}

--- a/frontend/src/components/SDEngine.tsx
+++ b/frontend/src/components/SDEngine.tsx
@@ -8,10 +8,11 @@ interface ImageFetcherProps {
     dbName: string;
     label: string;
     cellId: string;
+    imgType: 'ph' | 'fluo1' | 'fluo2';
 }
 const url_prefix = settings.url_prefix;
 
-const SDEngine: React.FC<ImageFetcherProps> = ({ dbName, label, cellId }) => {
+const SDEngine: React.FC<ImageFetcherProps> = ({ dbName, label, cellId, imgType }) => {
     const [imageUrl, setImageUrl] = useState<string | null>(null);
     const [loading, setLoading] = useState<boolean>(false);
 
@@ -19,7 +20,10 @@ const SDEngine: React.FC<ImageFetcherProps> = ({ dbName, label, cellId }) => {
         const fetchImageData = async () => {
             setLoading(true);
             try {
-                const response = await axios.get(`${url_prefix}/cells/${dbName}/${label}/${cellId}/sd_fluo_intensities`, { responseType: 'blob' });
+                const response = await axios.get(
+                    `${url_prefix}/cells/${dbName}/${label}/${cellId}/sd_fluo_intensities?img_type=${imgType}`,
+                    { responseType: 'blob' }
+                );
                 const imageBlobUrl = URL.createObjectURL(response.data);
                 setImageUrl(imageBlobUrl);
             } catch (error) {
@@ -35,7 +39,10 @@ const SDEngine: React.FC<ImageFetcherProps> = ({ dbName, label, cellId }) => {
 
     const handleDownloadCsv = async () => {
         try {
-            const response = await axios.get(`${url_prefix}/cells/${dbName}/${label}/sd_fluo_intensities/csv`, { responseType: 'blob' });
+            const response = await axios.get(
+                `${url_prefix}/cells/${dbName}/${label}/sd_fluo_intensities/csv?img_type=${imgType}`,
+                { responseType: 'blob' }
+            );
             const url = window.URL.createObjectURL(new Blob([response.data]));
             const link = document.createElement('a');
             link.href = url;


### PR DESCRIPTION
## Summary
- extend backend endpoints so `sd_fluo_intensities` and `cv_fluo_intensities` accept a new `img_type` parameter
- update CSV routes to handle `img_type`
- support `img_type` in CRUD helpers
- add `imgType` prop to `SDEngine` and `CVEngine` components and pass through from `CellOverview`
- expose a UI selector in `CellOverview` for choosing ph, fluo1 or fluo2 when using SD/CV engines

## Testing
- `bash backend/app/run_tests.sh` *(fails: ModuleNotFoundError: No module named 'httpx')*
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_688328f0b1dc832db27d0beb76b164a4