### PR TITLE
Enable area vs sd/cv exports

### DIFF
--- a/backend/app/TimeLapseEngine/crud.py
+++ b/backend/app/TimeLapseEngine/crud.py
@@ -1782,6 +1782,36 @@ class TimelapseDatabaseCrud:
         buf.seek(0)
         return StreamingResponse(buf, media_type="text/csv")
 
+    async def get_area_vs_sd_csv_by_cell_number(
+        self,
+        field: str,
+        cell_number: int,
+        channel: Literal["ph", "fluo1", "fluo2"] = "ph",
+    ) -> StreamingResponse:
+        """Return CSV of contour area vs. pixel SD for each frame."""
+        areas = await self.get_contour_areas_by_cell_number(field, cell_number)
+        sds = await self.get_pixel_sd_by_cell_number(field, cell_number, channel)
+        df = pd.DataFrame({"area": areas, "sd": sds})
+        buf = io.BytesIO()
+        df.to_csv(buf, index=False)
+        buf.seek(0)
+        return StreamingResponse(buf, media_type="text/csv")
+
+    async def get_area_vs_cv_csv_by_cell_number(
+        self,
+        field: str,
+        cell_number: int,
+        channel: Literal["ph", "fluo1", "fluo2"] = "ph",
+    ) -> StreamingResponse:
+        """Return CSV of contour area vs. pixel CV for each frame."""
+        areas = await self.get_contour_areas_by_cell_number(field, cell_number)
+        cvs = await self.get_pixel_cv_by_cell_number(field, cell_number, channel)
+        df = pd.DataFrame({"area": areas, "cv": cvs})
+        buf = io.BytesIO()
+        df.to_csv(buf, index=False)
+        buf.seek(0)
+        return StreamingResponse(buf, media_type="text/csv")
+
     async def replot_cell(
         self,
         field: str,

--- a/backend/app/TimeLapseEngine/router.py
+++ b/backend/app/TimeLapseEngine/router.py
@@ -362,6 +362,28 @@ async def get_pixel_cv_csv_by_cell_number(
     return await crud.get_pixel_cv_csv_by_cell_number(field, cell_number, channel)
 
 
+@router_tl_engine.get("/databases/{db_name}/cells/{field}/{cell_number}/area_vs_sd/csv")
+async def get_area_vs_sd_csv_by_cell_number(
+    db_name: str,
+    field: str,
+    cell_number: int,
+    channel: Literal["ph", "fluo1", "fluo2"] = "ph",
+):
+    crud = TimelapseDatabaseCrud(dbname=db_name)
+    return await crud.get_area_vs_sd_csv_by_cell_number(field, cell_number, channel)
+
+
+@router_tl_engine.get("/databases/{db_name}/cells/{field}/{cell_number}/area_vs_cv/csv")
+async def get_area_vs_cv_csv_by_cell_number(
+    db_name: str,
+    field: str,
+    cell_number: int,
+    channel: Literal["ph", "fluo1", "fluo2"] = "ph",
+):
+    crud = TimelapseDatabaseCrud(dbname=db_name)
+    return await crud.get_area_vs_cv_csv_by_cell_number(field, cell_number, channel)
+
+
 @router_tl_engine.get("/databases/{db_name}/cells/{field}/{cell_number}/replot")
 async def replot_cell(
     db_name: str,


### PR DESCRIPTION
## Summary
- add CSV endpoints for contour area vs pixel sd/cv
- support new endpoints in frontend with new draw modes and graphs

## Testing
- `./run_tests.sh` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_688336368d08832d9f2c807266eda982