### PR TITLE
Add MUI dark mode toggle

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,8 @@
 import "./App.css";
-import React, { useState } from "react";
+import React, { useState, useMemo, useEffect } from "react";
 import { Box } from "@mui/system";
+import { ThemeProvider, createTheme } from "@mui/material/styles";
+import CssBaseline from "@mui/material/CssBaseline";
 import { BrowserRouter as Router, Route, Routes } from "react-router-dom";
 import Nav from "./components/Nav";
 
@@ -78,12 +80,25 @@ function App() {
    true
   );
 
+  const [mode, setMode] = useState<'light' | 'dark'>(() => {
+    const saved = localStorage.getItem('themeMode');
+    return saved === 'dark' ? 'dark' : 'light';
+  });
+
+  const theme = useMemo(() => createTheme({ palette: { mode } }), [mode]);
+
+  useEffect(() => {
+    localStorage.setItem('themeMode', mode);
+  }, [mode]);
+
   return (
-    <Box sx={{ bgcolor: "#fff", color: "black", minHeight: "100vh" }}>
+    <ThemeProvider theme={theme}>
+      <CssBaseline />
+      <Box sx={{ bgcolor: 'background.default', color: 'text.primary', minHeight: '100vh' }}>
       {isAuthenticated ? (
         <Router>
           {/* ルーティングの外側に Nav を配置し、常時表示しておく */}
-          <Nav title="PhenoPixel5.0" />
+          <Nav title="PhenoPixel5.0" mode={mode} toggleMode={() => setMode(prev => prev === 'light' ? 'dark' : 'light')} />
 
           {/* ここからルーティング */}
           <Routes>
@@ -230,7 +245,8 @@ function App() {
         // パスワード保護
         <PasswordProtect setIsAuthenticated={setIsAuthenticated} />
       )}
-    </Box>
+      </Box>
+    </ThemeProvider>
   );
 }
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -82,7 +82,10 @@ function App() {
 
   const [mode, setMode] = useState<'light' | 'dark'>(() => {
     const saved = localStorage.getItem('themeMode');
-    return saved === 'dark' ? 'dark' : 'light';
+    if (saved === 'light' || saved === 'dark') {
+      return saved as 'light' | 'dark';
+    }
+    return 'dark';
   });
 
   const theme = useMemo(() => createTheme({ palette: { mode } }), [mode]);

--- a/frontend/src/components/HeatmapEngine.tsx
+++ b/frontend/src/components/HeatmapEngine.tsx
@@ -95,14 +95,7 @@ const HeatmapEngine: React.FC<ImageFetcherProps> = ({ dbName, label, cellId, deg
             <Button
                 variant="contained"
                 onClick={handleDownloadCsv}
-                sx={{
-                    color: 'black',
-                    backgroundColor: '#ffffff',
-                    '&:hover': {
-                        backgroundColor: '#e0e0e0',
-                    },
-                    marginTop: 1,
-                }}
+                sx={{ mt: 1 }}
                 startIcon={<DownloadIcon />}
             >
                 Download CSV
@@ -124,14 +117,7 @@ const HeatmapEngine: React.FC<ImageFetcherProps> = ({ dbName, label, cellId, deg
             <Button
                 variant="contained"
                 onClick={handleBulkDownloadCsv}
-                sx={{
-                    color: 'black',
-                    backgroundColor: '#ffffff',
-                    '&:hover': {
-                        backgroundColor: '#e0e0e0',
-                    },
-                    marginTop: 1,
-                }}
+                sx={{ mt: 1 }}
                 startIcon={<DownloadIcon />}
                 disabled={bulkLoading}
             >

--- a/frontend/src/components/Nav.tsx
+++ b/frontend/src/components/Nav.tsx
@@ -17,18 +17,22 @@ import GitHubIcon from '@mui/icons-material/GitHub';
 import AccountCircle from '@mui/icons-material/AccountCircle';
 import ScienceIcon from '@mui/icons-material/Science';
 import DatabaseIcon from '@mui/icons-material/Storage';
+import Brightness4Icon from '@mui/icons-material/Brightness4';
+import Brightness7Icon from '@mui/icons-material/Brightness7';
 import { settings } from '../settings';
 
 interface Props {
     window?: () => Window;
     title: string;
+    mode: 'light' | 'dark';
+    toggleMode: () => void;
 }
 
 const drawerWidth = 240;
 const navItems = [""];
 
 export default function Nav(props: Props) {
-    const { window } = props;
+    const { window, mode, toggleMode } = props;
     const [mobileOpen, setMobileOpen] = React.useState(false);
     const navigate = useNavigate();
 
@@ -64,22 +68,22 @@ export default function Nav(props: Props) {
     return (
         <Box sx={{ display: 'flex' }}>
             <CssBaseline />
-            <AppBar component="nav" sx={{ backgroundColor: '#fff' }}>
+            <AppBar component="nav">
                 <Toolbar>
                     <IconButton
                         color="inherit"
                         aria-label="open drawer"
                         edge="start"
                         onClick={handleDrawerToggle}
-                        sx={{ mr: 2, display: { sm: 'none' }, color: '#000' }}
+                        sx={{ mr: 2, display: { sm: 'none' } }}
                     >
                         <MenuIcon />
                     </IconButton>
-                    <Link to="/" style={{ textDecoration: 'none', color: '#000' }}>
+                    <Link to="/" style={{ textDecoration: 'none', color: 'inherit' }}>
                         <Typography
                             variant="h5"
                             component="div"
-                            sx={{ display: 'flex', alignItems: 'center', color: '#000' }}
+                            sx={{ display: 'flex', alignItems: 'center' }}
                         >
                             <Box
                                 component="img"
@@ -99,21 +103,18 @@ export default function Nav(props: Props) {
                     <IconButton
                         color="inherit"
                         onClick={() => navigate('/nd2files')}
-                        sx={{ color: '#000' }}
                     >
                         <ScienceIcon />
                     </IconButton>
                     <IconButton
                         color="inherit"
                         onClick={() => navigate('/dbconsole')}
-                        sx={{ color: '#000' }}
                     >
                         <DatabaseIcon />
                     </IconButton>
                     <IconButton
                         color="inherit"
                         component="a"
-                        sx={{ color: '#000' }}
                         href={`${settings.url_prefix}/docs`}
                         target="_blank"
                         rel="noopener noreferrer"
@@ -131,20 +132,21 @@ export default function Nav(props: Props) {
                         href="https://github.com/ikeda042/PhenoPixel5.0"
                         target="_blank"
                         rel="noopener noreferrer"
-                        sx={{ color: '#000' }}
                     >
                         <GitHubIcon />
+                    </IconButton>
+                    <IconButton color="inherit" onClick={toggleMode}>
+                        {mode === 'dark' ? <Brightness7Icon /> : <Brightness4Icon />}
                     </IconButton>
                     {isLoggedIn ? (
                         <IconButton
                             color="inherit"
                             onClick={() => navigate("/user_info")}
-                            sx={{ color: '#000' }}
                         >
                             <AccountCircle fontSize="large" />
                         </IconButton>
                     ) : (
-                        <Link to="/login" style={{ textDecoration: 'none', color: '#000' }}>
+                        <Link to="/login" style={{ textDecoration: 'none', color: 'inherit' }}>
                             <Typography variant="body1" sx={{ mr: 2 }}>Login</Typography>
                         </Link>
                     )}

--- a/frontend/src/components/Nav.tsx
+++ b/frontend/src/components/Nav.tsx
@@ -68,7 +68,13 @@ export default function Nav(props: Props) {
     return (
         <Box sx={{ display: 'flex' }}>
             <CssBaseline />
-            <AppBar component="nav">
+            <AppBar
+                component="nav"
+                sx={{
+                    bgcolor: mode === 'light' ? '#fff' : 'background.paper',
+                    color: mode === 'light' ? '#000' : 'text.primary',
+                }}
+            >
                 <Toolbar>
                     <IconButton
                         color="inherit"

--- a/frontend/src/components/Nav.tsx
+++ b/frontend/src/components/Nav.tsx
@@ -70,8 +70,10 @@ export default function Nav(props: Props) {
             <CssBaseline />
             <AppBar
                 component="nav"
+                color="default"
+                enableColorOnDark
                 sx={{
-                    bgcolor: mode === 'light' ? '#fff' : 'background.paper',
+                    backgroundColor: mode === 'light' ? '#fff' : 'background.paper',
                     color: mode === 'light' ? '#000' : 'text.primary',
                 }}
             >

--- a/frontend/src/components/SDEngine.tsx
+++ b/frontend/src/components/SDEngine.tsx
@@ -69,14 +69,7 @@ const SDEngine: React.FC<ImageFetcherProps> = ({ dbName, label, cellId, imgType 
             <Button
                 variant="contained"
                 onClick={handleDownloadCsv}
-                sx={{
-                    color: 'black',
-                    backgroundColor: '#ffffff',
-                    '&:hover': {
-                        backgroundColor: '#e0e0e0',
-                    },
-                    marginTop: 1,
-                }}
+                sx={{ mt: 1 }}
                 startIcon={<DownloadIcon />}
             >
                 Download CSV

--- a/frontend/src/components/VarEngine.tsx
+++ b/frontend/src/components/VarEngine.tsx
@@ -76,14 +76,7 @@ const VarEngine: React.FC<VarEngineProps> = ({ dbName, label, cellId }) => {
             <Button
                 variant="contained"
                 onClick={handleDownloadCsv}
-                sx={{
-                    color: 'black',
-                    backgroundColor: '#ffffff',
-                    '&:hover': {
-                        backgroundColor: '#e0e0e0',
-                    },
-                    marginTop: 1,
-                }}
+                sx={{ mt: 1 }}
                 startIcon={<DownloadIcon />}
             >
                 Download CSV


### PR DESCRIPTION
## Summary
- add ThemeProvider and mode state
- implement dark/light switch in navbar
- tweak buttons to use theme colors

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68833f812c20832db52888c91317ef9e