### PR TITLE
Fix theme reference in CDT

### DIFF
--- a/frontend/src/components/CDT.tsx
+++ b/frontend/src/components/CDT.tsx
@@ -16,7 +16,7 @@ import {
   TableRow,
   Paper,
 } from "@mui/material";
-import { styled } from "@mui/material/styles";
+import { styled, useTheme } from "@mui/material/styles";
 import axios from "axios";
 import { settings } from "../settings";
 
@@ -57,6 +57,7 @@ const StyledButton = styled("button")(({ theme }) => ({
 }));
 
 const CDT: React.FC = () => {
+  const theme = useTheme();
   const [ctrlFile, setCtrlFile] = useState<File | null>(null);
   const [files, setFiles] = useState<FileList | null>(null);
   const [results, setResults] = useState<ResultItem[]>([]);


### PR DESCRIPTION
## Summary
- import `useTheme` for the CDT component
- initialize `const theme = useTheme()` so CircularProgress can access the palette

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883528083d0832da11bb8ecfaa308b6