### PR TITLE
Add dark mode replot support

### DIFF
--- a/backend/app/CellDBConsole/crud.py
+++ b/backend/app/CellDBConsole/crud.py
@@ -1189,6 +1189,7 @@ class AsyncChores:
         image_fluo_raw: bytes,
         contour_raw: bytes,
         degree: int,
+        dark_mode: bool = False,
     ) -> io.BytesIO:
         """
         (u1,u2) 平面に生データを散布し、多項式近似した曲線と輪郭を表示。
@@ -1257,106 +1258,116 @@ class AsyncChores:
         min_u2_shifted = np.min(u2_shifted)
         max_u2_shifted = np.max(u2_shifted)
 
-        fig = plt.figure(figsize=(6, 6))
+        style = "dark_background" if dark_mode else "default"
+        text_kwargs = {"color": "white"} if dark_mode else {}
 
-        plt.scatter(u1_shifted, u2_shifted, s=5, label="Points in cell")
+        with plt.style.context(style):
+            fig = plt.figure(figsize=(6, 6))
 
-        plt.scatter([0], [0], color="red", s=100, label="Centroid (0,0)")
+            plt.scatter(u1_shifted, u2_shifted, s=5, label="Points in cell")
 
-        plt.axis("equal")
-        margin_width = 20
-        margin_height = 20
-        plt.scatter(
-            [i[1] for i in U_shifted],  # x
-            [i[0] for i in U_shifted],  # y
-            c=points_inside_cell_1,
-            cmap="jet",
-            marker="o",
-            s=20,
-            label="Intensity",
-        )
+            plt.scatter([0], [0], color="red", s=100, label="Centroid (0,0)")
 
-        plt.xlim([min_u1_shifted - margin_width, max_u1_shifted + margin_width])
-        plt.ylim([min_u2_shifted - margin_height, max_u2_shifted + margin_height])
+            plt.axis("equal")
+            margin_width = 20
+            margin_height = 20
+            plt.scatter(
+                [i[1] for i in U_shifted],  # x
+                [i[0] for i in U_shifted],  # y
+                c=points_inside_cell_1,
+                cmap="jet",
+                marker="o",
+                s=20,
+                label="Intensity",
+            )
 
-        max_val = np.max(points_inside_cell_1) if len(points_inside_cell_1) else 1
-        normalized_points = [i / max_val for i in points_inside_cell_1]
+            plt.xlim([min_u1_shifted - margin_width, max_u1_shifted + margin_width])
+            plt.ylim([min_u2_shifted - margin_height, max_u2_shifted + margin_height])
 
-        # テキストで統計量を表示
-        plt.text(
-            0.5,
-            0.20,
-            f"Median: {np.median(points_inside_cell_1):.2f}",
-            horizontalalignment="center",
-            verticalalignment="center",
-            transform=plt.gca().transAxes,
-        )
-        plt.text(
-            0.5,
-            0.15,
-            f"Mean: {np.mean(points_inside_cell_1):.2f}",
-            horizontalalignment="center",
-            verticalalignment="center",
-            transform=plt.gca().transAxes,
-        )
-        plt.text(
-            0.5,
-            0.10,
-            f"Normalized median: {np.median(normalized_points):.2f}",
-            horizontalalignment="center",
-            verticalalignment="center",
-            transform=plt.gca().transAxes,
-        )
-        plt.text(
-            0.5,
-            0.05,
-            f"Normalized mean: {np.mean(normalized_points):.2f}",
-            horizontalalignment="center",
-            verticalalignment="center",
-            transform=plt.gca().transAxes,
-        )
-        sd_val = np.std(points_inside_cell_1)
-        cv_val = sd_val / np.mean(points_inside_cell_1) if np.mean(points_inside_cell_1) != 0 else 0
-        plt.text(
-            0.5,
-            0.30,
-            f"SD: {sd_val:.2f}",
-            horizontalalignment="center",
-            verticalalignment="center",
-            transform=plt.gca().transAxes,
-        )
-        plt.text(
-            0.5,
-            0.25,
-            f"CV: {cv_val:.2f}",
-            horizontalalignment="center",
-            verticalalignment="center",
-            transform=plt.gca().transAxes,
-        )
+            max_val = np.max(points_inside_cell_1) if len(points_inside_cell_1) else 1
+            normalized_points = [i / max_val for i in points_inside_cell_1]
 
-        # 多項式近似のための x 軸生成: シフト後の範囲で
-        x_for_fit = np.linspace(min_u1_shifted, max_u1_shifted, 1000)
-        # シフト後の U を渡してフィッティング
-        theta = await AsyncChores.poly_fit(U_shifted, degree=degree)
-        y_for_fit = np.polyval(theta, x_for_fit)
+            # テキストで統計量を表示
+            plt.text(
+                0.5,
+                0.20,
+                f"Median: {np.median(points_inside_cell_1):.2f}",
+                horizontalalignment="center",
+                verticalalignment="center",
+                transform=plt.gca().transAxes,
+                **text_kwargs,
+            )
+            plt.text(
+                0.5,
+                0.15,
+                f"Mean: {np.mean(points_inside_cell_1):.2f}",
+                horizontalalignment="center",
+                verticalalignment="center",
+                transform=plt.gca().transAxes,
+                **text_kwargs,
+            )
+            plt.text(
+                0.5,
+                0.10,
+                f"Normalized median: {np.median(normalized_points):.2f}",
+                horizontalalignment="center",
+                verticalalignment="center",
+                transform=plt.gca().transAxes,
+                **text_kwargs,
+            )
+            plt.text(
+                0.5,
+                0.05,
+                f"Normalized mean: {np.mean(normalized_points):.2f}",
+                horizontalalignment="center",
+                verticalalignment="center",
+                transform=plt.gca().transAxes,
+                **text_kwargs,
+            )
+            sd_val = np.std(points_inside_cell_1)
+            cv_val = sd_val / np.mean(points_inside_cell_1) if np.mean(points_inside_cell_1) != 0 else 0
+            plt.text(
+                0.5,
+                0.30,
+                f"SD: {sd_val:.2f}",
+                horizontalalignment="center",
+                verticalalignment="center",
+                transform=plt.gca().transAxes,
+                **text_kwargs,
+            )
+            plt.text(
+                0.5,
+                0.25,
+                f"CV: {cv_val:.2f}",
+                horizontalalignment="center",
+                verticalalignment="center",
+                transform=plt.gca().transAxes,
+                **text_kwargs,
+            )
 
-        # 多項式近似曲線をプロット
-        plt.plot(x_for_fit, y_for_fit, color="red", label="Poly fit")
+            # 多項式近似のための x 軸生成: シフト後の範囲で
+            x_for_fit = np.linspace(min_u1_shifted, max_u1_shifted, 1000)
+            # シフト後の U を渡してフィッティング
+            theta = await AsyncChores.poly_fit(U_shifted, degree=degree)
+            y_for_fit = np.polyval(theta, x_for_fit)
 
-        # 輪郭を lime 色で描画 (シフト済み)
-        plt.scatter(
-            u1_contour_shifted, u2_contour_shifted, color="lime", s=20, label="Contour"
-        )
+            # 多項式近似曲線をプロット
+            plt.plot(x_for_fit, y_for_fit, color="red", label="Poly fit")
 
-        plt.tick_params(direction="in")
-        plt.grid(True)
-        plt.legend()
+            # 輪郭を lime 色で描画 (シフト済み)
+            plt.scatter(
+                u1_contour_shifted, u2_contour_shifted, color="lime", s=20, label="Contour"
+            )
 
-        # 出力用バッファ
-        buf = io.BytesIO()
-        fig.savefig(buf, format="png")
-        buf.seek(0)
-        plt.close(fig)
+            plt.tick_params(direction="in")
+            plt.grid(True)
+            plt.legend()
+
+            # 出力用バッファ
+            buf = io.BytesIO()
+            fig.savefig(buf, format="png")
+            buf.seek(0)
+            plt.close(fig)
 
         return buf
 
@@ -1645,12 +1656,12 @@ class CellCrudBase:
         )
 
     async def replot(
-        self, cell_id: str, degree: int, channel: int = 1
+        self, cell_id: str, degree: int, channel: int = 1, dark_mode: bool = False
     ) -> StreamingResponse:
         cell = await self.read_cell(cell_id)
         img = cell.img_fluo2 if channel == 2 else cell.img_fluo1
         return StreamingResponse(
-            await AsyncChores.replot(img, cell.contour, degree),
+            await AsyncChores.replot(img, cell.contour, degree, dark_mode),
             media_type="image/png",
         )
 

--- a/backend/app/CellDBConsole/router.py
+++ b/backend/app/CellDBConsole/router.py
@@ -244,11 +244,11 @@ async def get_cell_morphology(cell_id: str, db_name: str, polyfit_degree: int = 
 
 @router_cell.get("/{cell_id}/{db_name}/replot", response_class=StreamingResponse)
 async def replot_cell(
-    cell_id: str, db_name: str, degree: int = 3, channel: int = 1
+    cell_id: str, db_name: str, degree: int = 3, channel: int = 1, dark_mode: bool = False
 ):
     await AsyncChores().validate_database_name(db_name)
     return await CellCrudBase(db_name=db_name).replot(
-        cell_id=cell_id, degree=degree, channel=channel
+        cell_id=cell_id, degree=degree, channel=channel, dark_mode=dark_mode
     )
 
 

--- a/backend/app/TimeLapseEngine/crud.py
+++ b/backend/app/TimeLapseEngine/crud.py
@@ -1818,6 +1818,7 @@ class TimelapseDatabaseCrud:
         cell_number: int,
         channel: str,
         degree: int,
+        dark_mode: bool = False,
     ) -> io.BytesIO:
         async with get_session(self.dbname) as session:
             result = await session.execute(
@@ -1858,7 +1859,7 @@ class TimelapseDatabaseCrud:
             if hasattr(CellDBAsyncChores.replot, "cache_clear"):
                 CellDBAsyncChores.replot.cache_clear()
 
-            buf = await CellDBAsyncChores.replot(image_fluo_raw, cell.contour, degree)
+            buf = await CellDBAsyncChores.replot(image_fluo_raw, cell.contour, degree, dark_mode)
             buf.seek(0)
             frames.append(Image.open(buf))
 
@@ -2052,7 +2053,7 @@ class TimelapseDatabaseCrud:
                     return None
                 if hasattr(CellDBAsyncChores.replot, "cache_clear"):
                     CellDBAsyncChores.replot.cache_clear()
-                buf = await CellDBAsyncChores.replot(raw_blob, row.contour, degree)
+                buf = await CellDBAsyncChores.replot(raw_blob, row.contour, degree, dark_mode)
                 return buf.getvalue()
             else:
                 return raw_blob

--- a/backend/app/TimeLapseEngine/router.py
+++ b/backend/app/TimeLapseEngine/router.py
@@ -391,13 +391,14 @@ async def replot_cell(
     cell_number: int,
     channel: Literal["ph", "fluo1", "fluo2"] = "ph",
     degree: int = 4,
+    dark_mode: bool = False,
 ):
     """
     指定した field, cell_number, channel の全フレームを取得し、
     replot で生成した画像を GIF 化して返すエンドポイント。
     """
     crud = TimelapseDatabaseCrud(dbname=db_name)
-    gif_buffer = await crud.replot_cell(field, cell_number, channel, degree=4)
+    gif_buffer = await crud.replot_cell(field, cell_number, channel, degree=4, dark_mode=dark_mode)
     return StreamingResponse(
         gif_buffer,
         media_type="image/gif",

--- a/frontend/src/components/CellOverview.tsx
+++ b/frontend/src/components/CellOverview.tsx
@@ -18,6 +18,7 @@ import {
 import { SelectChangeEvent } from "@mui/material/Select";
 import { Scatter } from "react-chartjs-2";
 import { ChartOptions } from "chart.js";
+import { useTheme } from "@mui/material/styles";
 import Spinner from "./Spinner";
 import CellMorphologyTable from "./CellMorphoTable";
 import { settings } from "../settings";
@@ -153,6 +154,7 @@ const CellImageGrid: React.FC = () => {
   const db_name = searchParams.get("db_name") ?? "test_database.db";
   const cell_number = searchParams.get("cell") ?? "1";
   const init_draw_mode = (searchParams.get("init_draw_mode") ?? "light") as DrawModeType;
+  const theme = useTheme();
 
   // セルIDや画像などの状態管理
   const [cellIds, setCellIds] = useState<string[]>([]);
@@ -326,8 +328,9 @@ const CellImageGrid: React.FC = () => {
       switch (mode) {
         case "replot": {
           const channelParam = fluoChannel === 'fluo2' ? 2 : 1;
+          const dark = theme.palette.mode === "dark" ? "&dark_mode=true" : "";
           const response = await axios.get(
-            `${url_prefix}/cells/${cellId}/${db_name}/replot?degree=${fitDegree}&channel=${channelParam}`,
+            `${url_prefix}/cells/${cellId}/${db_name}/replot?degree=${fitDegree}&channel=${channelParam}${dark}`,
             { responseType: "blob" }
           );
           const url = URL.createObjectURL(response.data);

--- a/frontend/src/components/TimelapseCellOverview.tsx
+++ b/frontend/src/components/TimelapseCellOverview.tsx
@@ -416,7 +416,9 @@ const TimelapseViewer: React.FC = () => {
 
   // Replot 用 GIF
   const replotGifUrl = dbName
-    ? `${url_prefix}/tlengine/databases/${dbName}/cells/${selectedField}/${selectedCellNumber}/replot?channel=${replotChannel}&degree=4&duration=200&_syncKey=${reloadKey}`
+    ? `${url_prefix}/tlengine/databases/${dbName}/cells/${selectedField}/${selectedCellNumber}/replot?channel=${replotChannel}&degree=4${
+        theme.palette.mode === "dark" ? "&dark_mode=true" : ""
+      }&duration=200&_syncKey=${reloadKey}`
     : "";
 
   // ★ TimecoursePNG 用 URL (channel_mode="all_channels" でエンドポイントを切り替え)


### PR DESCRIPTION
## Summary
- allow `replot` endpoints to accept a `dark_mode` flag
- apply matplotlib dark background styling when `dark_mode` is true
- propagate `dark_mode` through timelapse handlers
- send dark-mode parameter from CellOverview and TimelapseCellOverview when theme is dark

## Testing
- `bash backend/app/run_tests.sh` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68836ee9ba00832d9f01f4006cf73ae1