### PR TITLE
Add bulk CSV export for timelapse databases

### DIFF
--- a/README.md
+++ b/README.md
@@ -826,6 +826,7 @@ All endpoints are prefixed with `/api`.
 | `GET` | `/tlengine/databases/{db}/fields/{field}/cell_numbers` | List cell numbers in a field. |
 | `PATCH` | `/tlengine/databases/{db}/cells/{base_cell_id}/label?label={label}` | Update `manual_label` for a base cell. |
 | `PATCH` | `/tlengine/databases/{db}/cells/{base_cell_id}/dead/{is_dead}` | Set dead status for a base cell. |
+| `GET` | `/tlengine/databases/{db}/cells/csv?is_dead={0\|1}` | Download cells as CSV filtered by `is_dead`. |
 | `GET` | `/tlengine/databases/{db}/cells/{field}/{cell_number}/replot` | Replot the entire time course as a GIF. |
 
 

--- a/backend/app/TimeLapseEngine/router.py
+++ b/backend/app/TimeLapseEngine/router.py
@@ -318,6 +318,16 @@ async def get_valid_until(db_name: str, base_cell_id: str):
     return JSONResponse(content={"valid_until": value})
 
 
+@router_tl_engine.get("/databases/{db_name}/cells/csv")
+async def get_cells_csv_by_dead_status(db_name: str, is_dead: int):
+    """
+    指定したデータベース(db_name)から is_dead フラグでフィルタしたセルをCSVで取得するエンドポイント。
+    is_dead=1 で dead, is_dead=0 で alive のセルを返します。
+    """
+    crud = TimelapseDatabaseCrud(dbname=db_name)
+    return await crud.get_cells_csv_by_dead_status(is_dead)
+
+
 @router_tl_engine.get("/databases/{db_name}/cells/{field}/{cell_number}/contour_areas")
 async def get_contour_areas_by_cell_number(db_name: str, field: str, cell_number: int):
     """

--- a/frontend/src/components/TimelapseDatabases.tsx
+++ b/frontend/src/components/TimelapseDatabases.tsx
@@ -192,6 +192,36 @@ const TimelapseDatabases: React.FC = () => {
   };
 
   /**
+   * 指定したDBのdead/aliveセルのCSVを一括ダウンロード
+   */
+  const handleBulkDownload = async (
+    dbName: string,
+    type: "dead" | "alive"
+  ) => {
+    try {
+      setLoading(true);
+      const isDead = type === "dead" ? 1 : 0;
+      const response = await axios.get(
+        `${url_prefix}/tlengine/databases/${dbName}/cells/csv?is_dead=${isDead}`,
+        { responseType: "blob" }
+      );
+      const blob = new Blob([response.data], { type: "text/csv" });
+      const url = window.URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = `${dbName}_${type}.csv`;
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+    } catch (err) {
+      console.error("Failed to download CSV:", err);
+      alert("Failed to download CSV");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  /**
    * モーダルを閉じる
    */
   const handleClosePreview = () => {
@@ -230,6 +260,7 @@ const TimelapseDatabases: React.FC = () => {
                 <TableCell align="center"><b>Database Name</b></TableCell>
                 <TableCell align="center"><b>Copy</b></TableCell>
                 <TableCell align="center"><b>Preview</b></TableCell>
+                <TableCell align="center"><b>CAV CSV</b></TableCell>
                 <TableCell align="center"><b>Access Database</b></TableCell>
               </TableRow>
             </TableHead>
@@ -319,6 +350,37 @@ const TimelapseDatabases: React.FC = () => {
                       onClick={() => handlePreview(database)}
                     >
                       Preview
+                    </Button>
+                  </TableCell>
+
+                  {/* CAV CSV */}
+                  <TableCell align="center">
+                    <Button
+                      variant="contained"
+                      size="small"
+                      sx={{
+                        backgroundColor: 'error.main',
+                        color: 'error.contrastText',
+                        fontSize: '0.8rem',
+                        '&:hover': { backgroundColor: 'error.dark' },
+                      }}
+                      onClick={() => handleBulkDownload(database, 'dead')}
+                    >
+                      Dead CSV
+                    </Button>
+                    <Button
+                      variant="contained"
+                      size="small"
+                      sx={{
+                        ml: 1,
+                        backgroundColor: 'success.main',
+                        color: 'success.contrastText',
+                        fontSize: '0.8rem',
+                        '&:hover': { backgroundColor: 'success.dark' },
+                      }}
+                      onClick={() => handleBulkDownload(database, 'alive')}
+                    >
+                      Alive CSV
                     </Button>
                   </TableCell>
 


### PR DESCRIPTION
## Summary
- add endpoint to export cells as CSV filtered by dead/alive labels
- extend database console with CAV CSV column and download buttons
- document new bulk CSV endpoint

## Testing
- `./run_tests.sh` *(fails: ImportError: libGL.so.1)*
- `apt-get update` *(fails: repository not signed)*
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6891971c12c4832db1b8155c5a98e3ee