### PR TITLE
feat: add draw mode selection for CAV CSV

### DIFF
--- a/backend/app/TimeLapseEngine/router.py
+++ b/backend/app/TimeLapseEngine/router.py
@@ -319,13 +319,19 @@ async def get_valid_until(db_name: str, base_cell_id: str):
 
 
 @router_tl_engine.get("/databases/{db_name}/cells/csv")
-async def get_cells_csv_by_dead_status(db_name: str, is_dead: int):
+async def get_cells_csv_by_dead_status(
+    db_name: str,
+    is_dead: int,
+    draw_mode: str = "basic",
+    channel: Literal["ph", "fluo1", "fluo2"] = "ph",
+):
     """
     指定したデータベース(db_name)から is_dead フラグでフィルタしたセルをCSVで取得するエンドポイント。
     is_dead=1 で dead, is_dead=0 で alive のセルを返します。
+    draw_mode で追加出力する値を選択できます。
     """
     crud = TimelapseDatabaseCrud(dbname=db_name)
-    return await crud.get_cells_csv_by_dead_status(is_dead)
+    return await crud.get_cells_csv_by_dead_status(is_dead, draw_mode, channel)
 
 
 @router_tl_engine.get("/databases/{db_name}/cells/{field}/{cell_number}/contour_areas")


### PR DESCRIPTION
## Summary
- allow choosing draw mode for CAV CSV downloads in Timelapse databases
- support draw mode parameter in CAV CSV backend endpoint
- compute pixel and area statistics per draw mode when exporting CSV

## Testing
- `./run_tests.sh` *(fails: ImportError: libGL.so.1: cannot open shared object file)*
- `npm test --prefix frontend -- --watchAll=false` *(fails: react-scripts not found)*
- `npm install --prefix frontend` *(fails: dependency resolution conflict)*

------
https://chatgpt.com/codex/tasks/task_e_68919cc38b64832da5a9d0cf87e69a20