### PR TITLE
feat: filter timelapse csv by manual label

### DIFF
--- a/README.md
+++ b/README.md
@@ -826,7 +826,7 @@ All endpoints are prefixed with `/api`.
 | `GET` | `/tlengine/databases/{db}/fields/{field}/cell_numbers` | List cell numbers in a field. |
 | `PATCH` | `/tlengine/databases/{db}/cells/{base_cell_id}/label?label={label}` | Update `manual_label` for a base cell. |
 | `PATCH` | `/tlengine/databases/{db}/cells/{base_cell_id}/dead/{is_dead}` | Set dead status for a base cell. |
-| `GET` | `/tlengine/databases/{db}/cells/csv?is_dead={0\|1}` | Download cells as CSV filtered by `is_dead`. |
+| `GET` | `/tlengine/databases/{db}/cells/csv?is_dead={0\|1}&manual_label={label}` | Download cells as CSV filtered by `is_dead` or `manual_label`. |
 | `GET` | `/tlengine/databases/{db}/cells/{field}/{cell_number}/replot` | Replot the entire time course as a GIF. |
 
 

--- a/backend/app/TimeLapseEngine/crud.py
+++ b/backend/app/TimeLapseEngine/crud.py
@@ -1759,15 +1759,19 @@ class TimelapseDatabaseCrud:
 
     async def get_cells_csv_by_dead_status(
         self,
-        is_dead: int,
+        is_dead: int | None = None,
         draw_mode: str = "basic",
         channel: Literal["ph", "fluo1", "fluo2"] = "ph",
+        manual_label: str | None = None,
     ) -> StreamingResponse:
-        """Return CSV of cells filtered by is_dead flag."""
+        """Return CSV of cells filtered by is_dead flag or manual label."""
         async with get_session(self.dbname) as session:
-            result = await session.execute(
-                select(Cell).where(Cell.is_dead == is_dead)
-            )
+            stmt = select(Cell)
+            if is_dead is not None:
+                stmt = stmt.where(Cell.is_dead == is_dead)
+            if manual_label is not None:
+                stmt = stmt.where(Cell.manual_label == manual_label)
+            result = await session.execute(stmt)
             cells = result.scalars().all()
 
         if draw_mode == "basic":

--- a/backend/app/TimeLapseEngine/router.py
+++ b/backend/app/TimeLapseEngine/router.py
@@ -321,17 +321,22 @@ async def get_valid_until(db_name: str, base_cell_id: str):
 @router_tl_engine.get("/databases/{db_name}/cells/csv")
 async def get_cells_csv_by_dead_status(
     db_name: str,
-    is_dead: int,
+    is_dead: int | None = None,
     draw_mode: str = "basic",
     channel: Literal["ph", "fluo1", "fluo2"] = "ph",
+    manual_label: str | None = None,
 ):
     """
-    指定したデータベース(db_name)から is_dead フラグでフィルタしたセルをCSVで取得するエンドポイント。
+    指定したデータベース(db_name)から is_dead フラグや manual_label で
+    フィルタしたセルをCSVで取得するエンドポイント。
     is_dead=1 で dead, is_dead=0 で alive のセルを返します。
+    manual_label を指定するとそのラベルに一致するセルだけを返します。
     draw_mode で追加出力する値を選択できます。
     """
     crud = TimelapseDatabaseCrud(dbname=db_name)
-    return await crud.get_cells_csv_by_dead_status(is_dead, draw_mode, channel)
+    return await crud.get_cells_csv_by_dead_status(
+        is_dead, draw_mode, channel, manual_label
+    )
 
 
 @router_tl_engine.get("/databases/{db_name}/cells/{field}/{cell_number}/contour_areas")


### PR DESCRIPTION
## Summary
- allow filtering CSV export by `manual_label`
- document new `manual_label` query parameter

## Testing
- `pytest` *(fails: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68928f9a106c832d8b5564974b769f08