### PR TITLE
Filter timelapse CSV by manual label

### DIFF
--- a/frontend/src/components/TimelapseDatabases.tsx
+++ b/frontend/src/components/TimelapseDatabases.tsx
@@ -235,7 +235,7 @@ const TimelapseDatabases: React.FC = () => {
       const drawMode = selectedDrawModes[dbName] || "basic";
       const channel = selectedChannels[dbName] || "ph";
       const response = await axios.get(
-        `${url_prefix}/tlengine/databases/${dbName}/cells/csv?is_dead=${isDead}&draw_mode=${drawMode}&channel=${channel}`,
+        `${url_prefix}/tlengine/databases/${dbName}/cells/csv?is_dead=${isDead}&draw_mode=${drawMode}&channel=${channel}&manual_label=1`,
         { responseType: "blob" }
       );
       const blob = new Blob([response.data], { type: "text/csv" });


### PR DESCRIPTION
## Summary
- Limit timelapse CSV bulk downloads to only include cells with `manual_label=1`

## Testing
- `npm test` *(fails: react-scripts not found)*
- `./run_tests.sh` *(fails: libGL.so.1 missing)*

------
https://chatgpt.com/codex/tasks/task_e_6892eb43aea8832d85991d893f8ca4c9