### PR TITLE
Add PixelEngine export for labeled cell pixel intensities

### DIFF
--- a/backend/app/CellDBConsole/router.py
+++ b/backend/app/CellDBConsole/router.py
@@ -475,6 +475,28 @@ async def get_cv_fluo_intensities_csv(
 
 
 @router_cell.get(
+    "/{db_name}/{label}/pixel_engine/csv", response_class=StreamingResponse
+)
+async def export_pixel_engine_csv(
+    db_name: str,
+    label: str,
+    img_type: Literal["ph", "fluo1", "fluo2"] = "fluo1",
+):
+    await AsyncChores().validate_database_name(db_name)
+    normalized_label: str | None
+    if label == "74":
+        normalized_label = None
+    elif label == "1000":
+        normalized_label = "N/A"
+    else:
+        normalized_label = label
+
+    return await CellCrudBase(db_name=db_name).get_pixel_intensities_csv(
+        label=normalized_label, img_type=img_type
+    )
+
+
+@router_cell.get(
     "/{db_name}/{label}/area_fraction/csv", response_class=StreamingResponse
 )
 async def get_area_fraction_csv(db_name: str, label: str):

--- a/frontend/src/components/CellOverview.tsx
+++ b/frontend/src/components/CellOverview.tsx
@@ -30,6 +30,7 @@ import VarEngine from "./VarEngine";
 import AreaFractionEngine from "./AreaFractionEngine";
 import SDEngine from "./SDEngine";
 import PixelCVEngine from "./PixelCVEngine";
+import PixelEngine from "./PixelEngine";
 
 import {
   Chart as ChartJS,
@@ -99,7 +100,8 @@ type EngineName =
   | "VarEngine"
   | "AreaFractionEngine"
   | "SDEngine"
-  | "PixelCVEngine";
+  | "PixelCVEngine"
+  | "PixelEngine";
 
 // MorphoEngineロゴマッピング
 const engineLogos: Record<EngineName, string> = {
@@ -112,6 +114,7 @@ const engineLogos: Record<EngineName, string> = {
   HeatmapEngine: "/logo_heatmap.png",
   SDEngine: "/var_logo.png",
   PixelCVEngine: "/var_logo.png",
+  PixelEngine: "/var_logo.png",
 };
 
 //-----------------------------------
@@ -143,6 +146,14 @@ const DRAW_MODES: {
   { value: "prediction", label: "Model T1(Torch GPU)" },
   { value: "cloud_points", label: "3D Fluo" },
   { value: "cloud_points_ph", label: "3D PH" },
+];
+
+const LABEL_OPTIONS: { value: string; label: string }[] = [
+  { value: "74", label: "All" },
+  { value: "1000", label: "N/A" },
+  { value: "1", label: "1" },
+  { value: "2", label: "2" },
+  { value: "3", label: "3" },
 ];
 
 //-----------------------------------
@@ -813,11 +824,11 @@ const CellImageGrid: React.FC = () => {
                     value={selectedLabel}
                     onChange={handleLabelChange}
                   >
-                    <MenuItem value="74">All</MenuItem>
-                    <MenuItem value="1000">N/A</MenuItem>
-                    <MenuItem value="1">1</MenuItem>
-                    <MenuItem value="2">2</MenuItem>
-                    <MenuItem value="3">3</MenuItem>
+                    {LABEL_OPTIONS.map((option) => (
+                      <MenuItem key={option.value} value={option.value}>
+                        {option.label}
+                      </MenuItem>
+                    ))}
                   </Select>
                 </FormControl>
               </Grid>
@@ -1480,7 +1491,9 @@ const CellImageGrid: React.FC = () => {
             </FormControl>
           </Box>
 
-          {(engineMode === "SDEngine" || engineMode === "PixelCVEngine") && (
+          {(engineMode === "SDEngine" ||
+            engineMode === "PixelCVEngine" ||
+            engineMode === "PixelEngine") && (
             <Box sx={{ mb: 2 }}>
               <FormControl fullWidth variant="outlined">
                 <InputLabel id="stat-source-label">Channel</InputLabel>
@@ -1577,6 +1590,18 @@ const CellImageGrid: React.FC = () => {
                 label={selectedLabel}
                 cellId={cellIds[currentIndex]}
                 imgType={statSource}
+              />
+            </Box>
+          )}
+
+          {engineMode === "PixelEngine" && (
+            <Box mt={6}>
+              <PixelEngine
+                dbName={db_name}
+                label={selectedLabel}
+                imgType={statSource}
+                labelOptions={LABEL_OPTIONS}
+                onLabelChange={(value) => setSelectedLabel(value)}
               />
             </Box>
           )}

--- a/frontend/src/components/PixelEngine.tsx
+++ b/frontend/src/components/PixelEngine.tsx
@@ -1,0 +1,119 @@
+import React, { useState } from "react";
+import axios from "axios";
+import {
+  Box,
+  Button,
+  CircularProgress,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  Typography,
+} from "@mui/material";
+import { SelectChangeEvent } from "@mui/material/Select";
+import DownloadIcon from "@mui/icons-material/Download";
+
+import { settings } from "../settings";
+
+interface LabelOption {
+  value: string;
+  label: string;
+}
+
+interface PixelEngineProps {
+  dbName: string;
+  label: string;
+  imgType: "ph" | "fluo1" | "fluo2";
+  labelOptions?: LabelOption[];
+  onLabelChange?: (value: string) => void;
+}
+
+const url_prefix = settings.url_prefix;
+
+const PixelEngine: React.FC<PixelEngineProps> = ({
+  dbName,
+  label,
+  imgType,
+  labelOptions = [],
+  onLabelChange,
+}) => {
+  const [isExporting, setIsExporting] = useState(false);
+
+  const handleExport = async () => {
+    setIsExporting(true);
+    try {
+      const response = await axios.get(
+        `${url_prefix}/cells/${dbName}/${label}/pixel_engine/csv?img_type=${imgType}`,
+        { responseType: "blob" }
+      );
+      const blob = new Blob([response.data], { type: "text/csv" });
+      const downloadUrl = window.URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      const labelForName = label === "74" ? "all" : label === "1000" ? "NA" : label;
+      link.href = downloadUrl;
+      link.setAttribute(
+        "download",
+        `${dbName}_label_${labelForName}_${imgType}_pixels.csv`
+      );
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      window.URL.revokeObjectURL(downloadUrl);
+    } catch (error) {
+      console.error("Failed to export pixel intensities:", error);
+    } finally {
+      setIsExporting(false);
+    }
+  };
+
+  const handleLabelSelect = (event: SelectChangeEvent<string>) => {
+    const newValue = event.target.value as string;
+    onLabelChange?.(newValue);
+  };
+
+  return (
+    <Box display="flex" flexDirection="column" gap={2}>
+      {labelOptions.length > 0 && onLabelChange && (
+        <FormControl fullWidth size="small">
+          <InputLabel id="pixel-engine-label-select">Label</InputLabel>
+          <Select
+            labelId="pixel-engine-label-select"
+            value={label}
+            label="Label"
+            onChange={handleLabelSelect}
+          >
+            {labelOptions.map((option) => (
+              <MenuItem key={option.value} value={option.value}>
+                {option.label}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+      )}
+
+      <Typography variant="body2" color="text.secondary">
+        Export a CSV where each row corresponds to a cell and contains its pixel
+        intensities for the selected label and channel.
+      </Typography>
+
+      <Box>
+        <Button
+          variant="contained"
+          onClick={handleExport}
+          disabled={isExporting}
+          startIcon={
+            isExporting ? (
+              <CircularProgress size={16} color="inherit" />
+            ) : (
+              <DownloadIcon />
+            )
+          }
+        >
+          {isExporting ? "Exporting..." : "Export"}
+        </Button>
+      </Box>
+    </Box>
+  );
+};
+
+export default PixelEngine;


### PR DESCRIPTION
## Summary
- add a backend helper that flattens pixel intensities per cell into CSV rows and expose it via a /pixel_engine endpoint
- introduce a PixelEngine panel in CellOverview so users can pick labels/channels and export the generated CSV

## Testing
- npm install *(fails: registry returned 403 for lucide-react)*

------
https://chatgpt.com/codex/tasks/task_e_68cca159d728832da1cf703d39c4b498